### PR TITLE
Add account lockout after successive failed login attempts

### DIFF
--- a/src/models/User.js
+++ b/src/models/User.js
@@ -4,7 +4,8 @@ const UserSchema = new mongoose.Schema({
   username: { type: String, required: true, unique: true },
   email: { type: String, required: true, unique: true },
   password_hash: { type: String, required: true },
-  lastPasswordChange: { type: Date, default: Date.now }, 
+  lastPasswordChange: { type: Date, default: Date.now },
+  failedLoginAttempts: { type: Number, default: 0 },
   created_at: { type: Date, default: Date.now },
   updated_at: { type: Date, default: Date.now }
 });

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -17,12 +17,11 @@ router.post('/register', async (req, res) => {
     const salt = await bcrypt.genSalt(10);
     const hashedPassword = await bcrypt.hash(password, salt);
 
-   
     const newUser = new User({
       username: username,
       email: email,
       password_hash: hashedPassword,
-      lastPasswordChange: Date.now() 
+      lastPasswordChange: Date.now()
     });
 
     await newUser.save();
@@ -46,7 +45,18 @@ router.post('/login', async (req, res) => {
     if (!user) return res.status(400).json({ error: 'User not found' });
 
     const isValidPassword = await bcrypt.compare(req.body.password, user.password_hash);
-    if (!isValidPassword) return res.status(400).json({ error: 'Invalid password' });
+    if (!isValidPassword) {
+      user.failedLoginAttempts = (user.failedLoginAttempts !== null && user.failedLoginAttempts !== undefined) ? user.failedLoginAttempts + 1 : 1;
+      await user.save();
+      return res.status(400).json({ error: 'Incorrect email and password combination'});
+    }
+
+    if (user.failedLoginAttempts !== null && user.failedLoginAttempts !== undefined && user.failedLoginAttempts > 4) {
+      return res.status(400).json({ error: 'Your account has been flagged and locked. Please reset your password' });
+    }
+
+    user.failedLoginAttempts = 0;
+    await user.save();
 
     const token = jwt.sign(
       { _id: user._id, username: user.username },
@@ -55,9 +65,9 @@ router.post('/login', async (req, res) => {
     );
 
     const currentDate = new Date();
-    const lastChangeDate = new Date(user.lastPasswordChange); 
+    const lastChangeDate = new Date(user.lastPasswordChange);
 
-    const timeDifference = currentDate.getTime() - lastChangeDate.getTime(); 
+    const timeDifference = currentDate.getTime() - lastChangeDate.getTime();
     const daysSinceLastChange = Math.floor(timeDifference / (1000 * 60 * 60 * 24));
     const daysRemaining = 90 - daysSinceLastChange;
 
@@ -96,6 +106,11 @@ router.post('/change-password', verifyToken, async (req, res) => {
     }
 
     const user = await User.findById(req.user._id);
+    
+    if (!user) {
+      return res.status(404).send({ error: 'User not found' });
+    }
+
     const isValidPassword = await bcrypt.compare(oldPassword, user.password_hash);
 
     if (!isValidPassword) {
@@ -106,7 +121,8 @@ router.post('/change-password', verifyToken, async (req, res) => {
     const hashedNewPassword = await bcrypt.hash(newPassword, salt);
 
     user.password_hash = hashedNewPassword;
-    user.lastPasswordChange = Date.now(); 
+    user.lastPasswordChange = Date.now();
+    user.failedLoginAttempts = 0;
     await user.save();
 
     res.status(200).json({ message: 'Password changed successfully' });
@@ -115,9 +131,43 @@ router.post('/change-password', verifyToken, async (req, res) => {
   }
 });
 
+// TODO: This endpoint will have to bo improved to send an email to the user with the token
+router.post('/reset-password', verifyToken, async (req, res) => {
+  try {
+    const { email, newPassword, confirmPassword } = req.body;
+
+    if (!email || !newPassword || !confirmPassword) {
+      return res.status(400).json({ error: 'All fields are required' });
+    }
+
+    if (newPassword !== confirmPassword) {
+      return res.status(400).json({ error: 'New password and confirmation do not match' });
+    }
+
+    const user = await User.findOne({ email: req.body.email });
+    
+    if (!user) {
+      return res.status(404).send({ error: 'User not found' });
+    }
+
+    const salt = await bcrypt.genSalt(10);
+    const hashedNewPassword = await bcrypt.hash(newPassword, salt);
+
+    user.password_hash = hashedNewPassword;
+    user.lastPasswordChange = Date.now();
+    user.failedLoginAttempts = 0;
+    await user.save();
+
+    res.status(200).json({ message: 'Password reset successful' });
+  } catch (error) {
+    res.status(400).json({ error: error.message });
+  }
+});
+
+
 router.get('/', verifyToken, checkPasswordExpiry, async (req, res) => {
   try {
-    const users = await User.find().select('-password_hash'); 
+    const users = await User.find().select('-password_hash');
     res.status(200).json(users);
   } catch (error) {
     res.status(400).json({ error: error.message });

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -202,7 +202,8 @@ router.post('/reset-password', async (req, res) => {
     const hashedNewPassword = await bcrypt.hash(newPassword, salt);
 
     user.password_hash = hashedNewPassword;
-    user.lastPasswordChange = Date.now(); 
+    user.lastPasswordChange = Date.now();
+    user.failedLoginAttempts = 0;
     await user.save();
 
     res.status(200).json({ message: 'Password has been updated successfully' });


### PR DESCRIPTION
## Description

The changes here adds an account lockout feature where the user is not allowed access to their account after `5` successive failed login attempts. This prompts them to reset their password, and doing so unlocks their account.

### Todos

- [x] Tested and working locally
- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] Code changes documented
- [x] Requested review from >= 1 devs on the team

### How to test

Endpoints to target and try out are:
1. `{{base_url}}/api/users/login` to login.
2. `{{base_url}}/api/users/reset-password` to reset the password.

### Screenshots and/or Gifs
<img width="1282" alt="Screenshot 2024-09-20 at 7 30 52 am" src="https://github.com/user-attachments/assets/6a8f55db-e0c1-4fde-9bab-9ddb4bbb5074">

<img width="1279" alt="Screenshot 2024-09-20 at 7 31 27 am" src="https://github.com/user-attachments/assets/cdeeece3-ff70-486d-bff2-e60a96d9fbf7">


### Associated MS Planner Tasks

- [Add Account Lockout Feature](https://planner.cloud.microsoft/deakin365.onmicrosoft.com/Home/Task/7ijYI1CrcEClMXm-ouxtJcgANbNA?Type=TaskLink&Channel=Link&CreatedTime=638623786739170000)
