### PR TITLE
feat(audit): add central AuditLog + async logger + admin listing

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,0 @@
-BASE_URL=http://localhost:3000
-MONGODB_URI="mongodb://localhost:27017/guardian"
-PORT=3000
-NODE_ENV=development
-JWT_SECRET=your_jwt_secret_key

--- a/AUDIT_LOGGING.md
+++ b/AUDIT_LOGGING.md
@@ -1,0 +1,276 @@
+# Audit Logging System — Team Guide & Test Cases
+
+> This document includes reference for how our **AuditLog** works, how to **test** it, and how to **extend** it safely.  
+> **Scope:** Auth, authorization (RBAC), and task operations, extensible to other domains (patients, care plans, tickets) without changing existing behavior.
+
+---
+
+## 1. What We Log (and Why)
+
+We store **permanent** audit records of sensitive events to support:
+- **Security monitoring** (e.g., failed logins, token issues)
+- **Compliance** (provable access/change history)
+- **Operational debugging** (who did what, when, where)
+- **Analytics & notifications** (optionally trigger alerts for critical events)
+
+**Categories & sample actions**
+- `auth`: `login_success`, `login_failed`, `login_locked`, `token_invalid`, `token_expired`
+- `authorization`: `permission_denied`, `permission_check_failed`
+- `tasks`: `task_created`, `task_updated`, `task_deleted`
+
+---
+
+## 2. Log Structure (Schema & Fields)
+
+**Collection:** `auditlogs`  
+**Indexes:** recommended on `createdAt`, `category`, `action` 
+
+```jsonc
+{
+  "_id": "ObjectId",
+  "category": "auth",                        // logical group
+  "action": "login_failed",                  // specific event
+  "actor": "66bd9b1c2e3f1b4d9a123456",      // userId (if known)
+  "status": "failure",                       // "success" | "failure"
+  "meta": { "reason": "invalid_credentials" }, // compact context only
+  "ipAddress": "203.0.113.24",
+  "userAgent": "PostmanRuntime/7.39.0",
+  "createdAt": "2025-08-15T10:00:00.000Z"
+}
+````
+
+**Field notes**
+
+* `actor`: omit if unauthenticated (e.g., unknown email during login).
+* `meta`: only compact keys (e.g., `reason`, `resourceId`, `role`, `taskId`). Never raw secrets.
+
+---
+
+## 3. Where Logs Are Emitted
+
+Refers to typical placements in this project:
+
+* **Auth**
+
+  * `src/controllers/userController.js` → on login success/failure/lock
+  * `src/middleware/verifyToken.js` → `token_invalid`, `token_expired`
+
+* **Authorization (RBAC)**
+
+  * `src/middleware/verifyRole.js` → `permission_denied`, `permission_check_failed`
+
+* **Tasks**
+
+  * `src/controllers/adminController.js` → `task_created`, `task_updated`, `task_deleted`
+
+* **Admin listing (read-only)**
+
+  * `GET /api/v1/admin/audit-logs` in `src/routes/auditLogs.js` (no user-facing UI)
+
+---
+
+## 4. How to Add a New Log 
+
+1. **Pick a category**: `auth`, `authorization`, `tasks`, or introduce a new one (`patient`, `tickets`, …).
+2. **Name an action** (e.g., `patient_created`, `ticket_assigned`).
+3. **Emit log** using the async logger:
+
+```js
+const { audit } = require('../utils/audit'); // helper wraps model insert
+
+audit({
+  category: 'auth',
+  action: 'login_failed',
+  status: 'failure',
+  actor: user?._id,                          // optional
+  meta: { reason: 'invalid_credentials' },
+  req                                         // pass req to capture ip/user-agent
+});
+```
+
+> \[!TIP]
+> The helper should be **fire-and-forget** (e.g., `setImmediate`) so logging never blocks the main request path.
+
+---
+
+## 5. Test Cases for Common Log Types
+
+### 5.1 Postman Flow (Manual QA)
+
+> Use **Postman** for calls and **MongoDB Compass** to confirm records.
+> Create a Postman **Environment** with:
+>
+> * `baseUrl` = `http://localhost:3000`
+> * `adminToken` / `nurseToken` (set after login)
+
+---
+
+#### 1) Register Users (skip if they exist)
+
+* **POST** `{{baseUrl}}/api/v1/auth/register`
+  Headers: `Content-Type: application/json`
+
+**Admin**
+
+```json
+{ "fullname": "Admin Audit", "email": "admin.audit@example.com", "password": "AdminPass123!", "role": "admin" }
+```
+
+**Nurse**
+
+```json
+{ "fullname": "Nurse Audit", "email": "nurse.audit@example.com", "password": "NursePass123!", "role": "nurse" }
+```
+
+* **Expected:** `201 Created` (or `400` if already exists)
+
+---
+
+#### 2) Login & store tokens
+
+* **POST** `{{baseUrl}}/api/v1/auth/login`
+  Headers: `Content-Type: application/json`
+
+**Admin body**
+
+```json
+{ "email": "admin.audit@example.com", "password": "AdminPass123!" }
+```
+
+**Postman → Tests**
+
+```js
+pm.test("Status 200", () => pm.response.to.have.status(200));
+pm.environment.set("adminToken", pm.response.json().token);
+```
+
+**Nurse body**
+
+```json
+{ "email": "nurse.audit@example.com", "password": "NursePass123!" }
+```
+
+**Postman → Tests**
+
+```js
+pm.test("Status 200", () => pm.response.to.have.status(200));
+pm.environment.set("nurseToken", pm.response.json().token);
+```
+
+* **Expected:** `200 OK` and audit `auth: login_success`
+
+---
+
+#### 3) Auth failures
+
+**Unknown email**
+
+* **POST** `/api/v1/auth/login`
+
+```json
+{ "email": "nouser@example.com", "password": "SomePass123!" }
+```
+
+* **Expected:** `400` and audit `auth: login_failed`
+
+**Wrong password (nurse)** — run \~5 times
+
+```json
+{ "email": "nurse.audit@example.com", "password": "WrongPass!" }
+```
+
+* **Expected:** multiple `400` (login\_failed), then `400` lock → `auth: login_locked`
+
+---
+
+#### 4) Token errors
+
+**Missing/Bad Bearer**
+
+* **GET** `{{baseUrl}}/api/v1/alerts` (no `Authorization` or malformed)
+* **Expected:** `401` or `400`, audit `auth: token_invalid`
+
+**Invalid signature**
+
+* **GET** `{{baseUrl}}/api/v1/alerts`
+
+  * Headers: `Authorization: Bearer invalid.invalid.invalid`
+* **Expected:** `400`, audit `auth: token_invalid`
+
+---
+
+#### 5) RBAC (permission denied)
+
+**Nurse** requests admin-only listing:
+
+* **GET** `{{baseUrl}}/api/v1/admin/audit-logs?limit=2`
+  Headers: `Authorization: Bearer {{nurseToken}}`
+* **Expected:** `403`, audit `authorization: permission_denied`
+
+---
+
+#### 6) Admin lists audit logs
+
+* **GET** `{{baseUrl}}/api/v1/admin/audit-logs?limit=10`
+  Headers: `Authorization: Bearer {{adminToken}}`
+* **Expected:** `200` with `{ page, limit, total, items[] }`
+
+**Filter examples:**
+
+* `?category=auth&action=login_failed&limit=5`
+* `?category=authorization&action=permission_denied&limit=5`
+
+---
+
+#### 7) (Optional) Task events
+
+**If task routes are mounted**
+
+* **POST** `/api/v1/admin/tasks` → `task_created`
+* **PUT** `/api/v1/admin/tasks/:taskId` → `task_updated`
+* **DELETE** `/api/v1/admin/tasks/:taskId` → `task_deleted`
+  Headers: `Authorization: Bearer {{adminToken}}`
+
+---
+
+### 5.2 Verifying in MongoDB
+
+**MongoDB Compass**
+
+1. Open the database used by the app.
+2. Select `auditlogs`.
+3. **Sort** by `createdAt` **descending**.
+4. Confirm expected `category`, `action`, `status`, and `actor`.
+
+---
+
+## 6. Querying Audit Logs (Admin Endpoint)
+
+**Route:** `GET /api/v1/admin/audit-logs` (admin only)
+
+**Response**
+
+```json
+{
+  "page": 1,
+  "limit": 20,
+  "total": 123,
+  "items": "array of audit logs"
+}
+```
+
+---
+
+## 7. Retention, Indexing & Operations
+
+* **Retention:** keep permanent by default; if growth becomes an issue, introduce **archival** (e.g., move >90 days to `auditlogs_archive`).
+
+* **Indexes (recommended):**
+
+  * `{ createdAt: -1 }`
+  * `{ category: 1, action: 1, createdAt: -1 }`
+
+* **Throughput:** the logger is **async** (fire-and-forget) to keep latency negligible.
+
+---
+

--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -4,6 +4,7 @@ const Task = require('../models/Task');
 const CarePlan = require('../models/CarePlan');
 const SupportTicket = require('../models/SupportTicket');
 const Task = require('../models/Task');
+const { log: audit } = require('../utils/audit');
 
 /**
  * @swagger
@@ -291,6 +292,17 @@ exports.createTask = async (req, res) => {
     const newTask = new Task({ title, description, patient: patientId, dueDate, assignedTo });
     await newTask.save();
 
+    // AUDIT: task created
+    audit(req, {
+      category: 'task',
+      action: 'task_created',
+      actor: req.user?._id || null,
+      severity: 'info',
+      targetModel: 'Task',
+      targetId: String(newTask._id),
+      meta: { patientId, assignedTo },
+    });
+
     res.status(201).json({ message: 'Task created successfully', task: newTask });
   } catch (error) {
     res.status(500).json({ message: 'Error creating task', details: error.message });
@@ -354,6 +366,17 @@ exports.updateTask = async (req, res) => {
       return res.status(404).json({ message: 'Task not found' });
     }
 
+    // AUDIT: task updated (record changed keys only)
+    audit(req, {
+      category: 'task',
+      action: 'task_updated',
+      actor: req.user?._id || null,
+      severity: 'info',
+      targetModel: 'Task',
+      targetId: String(taskId),
+      meta: { changed: Object.keys(updateData || {}) },
+    });
+
     res.status(200).json({ message: 'Task updated successfully', task: updatedTask });
   } catch (error) {
     res.status(500).json({ message: 'Error updating task', details: error.message });
@@ -397,6 +420,16 @@ exports.deleteTask = async (req, res) => {
     if (!deletedTask) {
       return res.status(404).json({ message: 'Task not found' });
     }
+
+    // AUDIT: task deleted
+    audit(req, {
+      category: 'task',
+      action: 'task_deleted',
+      actor: req.user?._id || null,
+      severity: 'low',
+      targetModel: 'Task',
+      targetId: String(taskId),
+    });
 
     res.status(200).json({ message: 'Task deleted successfully' });
   } catch (error) {

--- a/src/middleware/verifyRole.js
+++ b/src/middleware/verifyRole.js
@@ -1,21 +1,44 @@
 const User = require('../models/User');
+const { log: audit } = require('../utils/audit'); 
 
-// Middleware to verify if the user has the required role
+// Middleware to verify if the user has the required role(s)
 const verifyRole = (roles) => async (req, res, next) => {
   try {
     const user = await User.findById(req.user._id).populate('role');
     if (!user || !user.role || !user.role.name) {
+      // AUDIT: missing role on user
+      audit(req, {
+        category: 'authorization',
+        action: 'permission_denied',
+        severity: 'medium',
+        meta: { reason: 'missing_role' },
+      });
       return res.status(403).json({ message: 'Access denied. Insufficient permissions.' });
     }
 
     const userRole = await user.role.name;
     if (!roles.includes(userRole)) {
+      // AUDIT: role not allowed
+      audit(req, {
+        category: 'authorization',
+        action: 'permission_denied',
+        actor: user._id,
+        severity: 'medium',
+        meta: { reason: 'role_not_allowed', required: roles, actual: userRole },
+      });
       return res.status(403).json({ message: 'Access denied. Insufficient permissions.' });
     }
 
     next();
   } catch (error) {
     console.error('Error verifying user role:', error);
+    // AUDIT: role check failure (system)
+    audit(req, {
+      category: 'authorization',
+      action: 'permission_check_failed',
+      severity: 'high',
+      meta: { reason: error.message.slice(0, 120) },
+    });
     res.status(500).json({ message: 'Failed to check user role' });
   }
 };

--- a/src/middleware/verifyToken.js
+++ b/src/middleware/verifyToken.js
@@ -1,30 +1,53 @@
 const jwt = require('jsonwebtoken');
+const { log: audit } = require('../utils/audit'); 
 
 const verifyToken = (req, res, next) => {
   const authHeader = req.header('Authorization');
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    // AUDIT: invalid token format
+    audit(req, {
+      category: 'auth',
+      action: 'token_invalid',
+      severity: 'medium',
+      meta: { reason: 'invalid_format' },
+    });
     return res.status(401).json({ message: 'Access denied. Invalid token format.' });
   }
 
-  const token = authHeader.split(' ')[1]; // Extract the token part
+  const token = authHeader.split(' ')[1];
   if (!token) {
+    // AUDIT: missing token
+    audit(req, {
+      category: 'auth',
+      action: 'token_invalid',
+      severity: 'medium',
+      meta: { reason: 'missing_token' },
+    });
     return res.status(401).json({ message: 'Access denied. No token provided.' });
   }
 
   try {
-    const verified = jwt.verify(token, process.env.JWT_SECRET, { algorithms: ['HS256'] }); // Specify algorithm
+    const verified = jwt.verify(token, process.env.JWT_SECRET, { algorithms: ['HS256'] });
     req.user = verified;
-
-    // Optional: Add role-based access control (RBAC) here
-    // if (req.user.role !== 'admin') {
-    //   return res.status(403).json({ message: 'Access denied. Insufficient permissions.' });
-    // }
-
     next();
   } catch (error) {
     if (error.name === 'TokenExpiredError') {
+      // AUDIT: expired token
+      audit(req, {
+        category: 'auth',
+        action: 'token_expired',
+        severity: 'medium',
+        meta: { reason: 'jwt_expired' },
+      });
       return res.status(401).json({ message: 'Access denied. Token has expired.' });
     }
+    // AUDIT: invalid token signature or decoding
+    audit(req, {
+      category: 'auth',
+      action: 'token_invalid',
+      severity: 'medium',
+      meta: { reason: error.message.slice(0, 120) },
+    });
     res.status(400).json({ message: 'Invalid token.' });
   }
 };

--- a/src/models/AuditLog.js
+++ b/src/models/AuditLog.js
@@ -1,0 +1,49 @@
+// Immutable audit trail for sensitive events. No TTL by design (permanent retention).
+const mongoose = require('mongoose');
+
+const AuditLogSchema = new mongoose.Schema(
+  {
+    // Actor may be null for unauthenticated events (e.g., failed login)
+    actor: { type: mongoose.Schema.Types.ObjectId, ref: 'User', index: true, default: null },
+
+    // Coarse category for fast filtering
+    category: {
+      type: String,
+      required: true,
+      enum: ['auth', 'authorization', 'task', 'patient', 'system'],
+      index: true,
+    },
+
+    // Specific event name (e.g., login_failed, permission_denied, task_updated)
+    action: { type: String, required: true, index: true },
+
+    // What object was acted on (optional)
+    targetModel: { type: String, default: null, index: true },
+    targetId: { type: String, default: null, index: true },
+
+    // signal for triage and triggers
+    severity: {
+      type: String,
+      enum: ['info', 'low', 'medium', 'high', 'critical'],
+      default: 'info',
+      index: true,
+    },
+
+    // Request context 
+    ip: { type: String, default: null },
+    userAgent: { type: String, default: null },
+
+    // metadata 
+    meta: { type: mongoose.Schema.Types.Mixed, default: {} },
+
+    createdAt: { type: Date, default: Date.now, index: true },
+  },
+  { versionKey: false }
+);
+
+// compound indexes
+AuditLogSchema.index({ category: 1, createdAt: -1 });
+AuditLogSchema.index({ action: 1, createdAt: -1 });
+AuditLogSchema.index({ severity: 1, createdAt: -1 });
+
+module.exports = mongoose.model('AuditLog', AuditLogSchema);

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -5,6 +5,7 @@ const User = require('../models/User');
 const verifyToken = require('../middleware/verifyToken');
 const verifyRole = require('../middleware/verifyRole');
 const adminController = require('../controllers/adminController');
+const AuditLog = require('../models/AuditLog');
 
 // Example route protected by role (only admins can access)
 router.post('/admin/approve-nurse/:nurseId', verifyToken, verifyRole(['admin']), async (req, res) => {
@@ -64,5 +65,37 @@ router.put('/support-tickets/:ticketId', verifyToken, verifyRole(['admin']), adm
 router.post('/tasks', verifyToken, verifyRole(['admin']), adminController.createTask);
 router.put('/tasks/:taskId', verifyToken, verifyRole(['admin']), adminController.updateTask);
 router.delete('/tasks/:taskId', verifyToken, verifyRole(['admin']), adminController.deleteTask);
+
+// Admin-only audit logs listing (read-only)
+router.get('/audit-logs', verifyToken, verifyRole(['admin']), async (req, res) => {
+  try {
+    const {
+      page = 1, limit = 50,
+      category, action, severity,
+      actor, targetModel, targetId,
+    } = req.query;
+
+    const q = {};
+    if (category) q.category = category;
+    if (action) q.action = action;
+    if (severity) q.severity = severity;
+    if (actor) q.actor = actor;
+    if (targetModel) q.targetModel = targetModel;
+    if (targetId) q.targetId = targetId;
+
+    const safeLimit = Math.min(200, Math.max(1, Number(limit)));
+    const safePage = Math.max(1, Number(page));
+    const skip = (safePage - 1) * safeLimit;
+
+    const [items, total] = await Promise.all([
+      AuditLog.find(q).sort({ createdAt: -1 }).skip(skip).limit(safeLimit).lean(),
+      AuditLog.countDocuments(q),
+    ]);
+
+    res.status(200).json({ page: safePage, limit: safeLimit, total, items });
+  } catch (err) {
+    res.status(500).json({ message: 'Error fetching audit logs', details: err.message });
+  }
+});
 
 module.exports = router;

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -5,7 +5,6 @@ const User = require('../models/User');
 const verifyToken = require('../middleware/verifyToken');
 const verifyRole = require('../middleware/verifyRole');
 const adminController = require('../controllers/adminController');
-const AuditLog = require('../models/AuditLog');
 
 // Example route protected by role (only admins can access)
 router.post('/admin/approve-nurse/:nurseId', verifyToken, verifyRole(['admin']), async (req, res) => {
@@ -65,37 +64,5 @@ router.put('/support-tickets/:ticketId', verifyToken, verifyRole(['admin']), adm
 router.post('/tasks', verifyToken, verifyRole(['admin']), adminController.createTask);
 router.put('/tasks/:taskId', verifyToken, verifyRole(['admin']), adminController.updateTask);
 router.delete('/tasks/:taskId', verifyToken, verifyRole(['admin']), adminController.deleteTask);
-
-// Admin-only audit logs listing (read-only)
-router.get('/audit-logs', verifyToken, verifyRole(['admin']), async (req, res) => {
-  try {
-    const {
-      page = 1, limit = 50,
-      category, action, severity,
-      actor, targetModel, targetId,
-    } = req.query;
-
-    const q = {};
-    if (category) q.category = category;
-    if (action) q.action = action;
-    if (severity) q.severity = severity;
-    if (actor) q.actor = actor;
-    if (targetModel) q.targetModel = targetModel;
-    if (targetId) q.targetId = targetId;
-
-    const safeLimit = Math.min(200, Math.max(1, Number(limit)));
-    const safePage = Math.max(1, Number(page));
-    const skip = (safePage - 1) * safeLimit;
-
-    const [items, total] = await Promise.all([
-      AuditLog.find(q).sort({ createdAt: -1 }).skip(skip).limit(safeLimit).lean(),
-      AuditLog.countDocuments(q),
-    ]);
-
-    res.status(200).json({ page: safePage, limit: safeLimit, total, items });
-  } catch (err) {
-    res.status(500).json({ message: 'Error fetching audit logs', details: err.message });
-  }
-});
 
 module.exports = router;

--- a/src/routes/auditLogs.js
+++ b/src/routes/auditLogs.js
@@ -6,11 +6,125 @@ const verifyToken = require('../middleware/verifyToken');
 const verifyRole = require('../middleware/verifyRole');
 
 /**
- * GET /api/v1/admin/audit-logs
- * Query params (all optional):
- *  - page (default 1)
- *  - limit (default 50, max 200)
- *  - category, action, severity, actor, targetModel, targetId
+ * @openapi
+ * tags:
+ *   - name: Audit Logs
+ *     description: Read-only endpoints for viewing audit logs (admin-only).
+ */
+
+/**
+ * @openapi
+ * components:
+ *   schemas:
+ *     AuditLog:
+ *       type: object
+ *       properties:
+ *         _id:
+ *           type: string
+ *           description: Log id
+ *           example: "66c8b3fd0c4b2a23d9c7f111"
+ *         category:
+ *           type: string
+ *           description: Logical group/category for the event
+ *           example: "auth"
+ *         action:
+ *           type: string
+ *           description: Specific action name
+ *           example: "LOGIN_SUCCESS"
+ *         severity:
+ *           type: string
+ *           description: Severity level
+ *           enum: [low, medium, high, critical]
+ *           example: "low"
+ *         actor:
+ *           type: string
+ *           description: User id or identifier of the actor
+ *           example: "64ef1cd4a1b7c00012ab34cd"
+ *         targetModel:
+ *           type: string
+ *           description: Model/entity type acted upon
+ *           example: "User"
+ *         targetId:
+ *           type: string
+ *           description: Identifier of the target entity
+ *           example: "64ef1cd4a1b7c00012ab3500"
+ *         details:
+ *           type: object
+ *           additionalProperties: true
+ *           description: Arbitrary structured context for the event
+ *           example:
+ *             ip: "203.0.113.9"
+ *             userAgent: "Mozilla/5.0 ..."
+ *             note: "Admin approved nurse account"
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *           example: "2025-08-12T03:14:15.926Z"
+ */
+
+/**
+ * @openapi
+ * /api/v1/admin/audit-logs:
+ *   get:
+ *     summary: List audit logs (paginated)
+ *     description: Read-only, filterable list of audit logs. Admin role required.
+ *     tags: [Audit Logs]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema: { type: integer, minimum: 1, default: 1 }
+ *         description: 1-based page index
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer, minimum: 1, maximum: 200, default: 50 }
+ *         description: Page size (max 200)
+ *       - in: query
+ *         name: category
+ *         schema: { type: string }
+ *         description: Filter by category
+ *       - in: query
+ *         name: action
+ *         schema: { type: string }
+ *         description: Filter by action
+ *       - in: query
+ *         name: severity
+ *         schema:
+ *           type: string
+ *           enum: [low, medium, high, critical]
+ *         description: Filter by severity
+ *       - in: query
+ *         name: actor
+ *         schema: { type: string }
+ *         description: Filter by actor id
+ *       - in: query
+ *         name: targetModel
+ *         schema: { type: string }
+ *         description: Filter by target model
+ *       - in: query
+ *         name: targetId
+ *         schema: { type: string }
+ *         description: Filter by target id
+ *     responses:
+ *       200:
+ *         description: Paginated audit logs
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 page: { type: integer, example: 1 }
+ *                 limit: { type: integer, example: 50 }
+ *                 total: { type: integer, example: 137 }
+ *                 items:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/AuditLog'
+ *       403:
+ *         description: Forbidden (missing/invalid token or role)
+ *       500:
+ *         description: Server error
  */
 router.get('/audit-logs', verifyToken, verifyRole(['admin']), async (req, res) => {
   try {

--- a/src/routes/auditLogs.js
+++ b/src/routes/auditLogs.js
@@ -1,0 +1,51 @@
+// Admin-only, read-only view into audit logs. Does not expose internal secrets.
+const express = require('express');
+const router = express.Router();
+const AuditLog = require('../models/AuditLog');
+const verifyToken = require('../middleware/verifyToken');
+const verifyRole = require('../middleware/verifyRole');
+
+/**
+ * GET /api/v1/admin/audit-logs
+ * Query params (all optional):
+ *  - page (default 1)
+ *  - limit (default 50, max 200)
+ *  - category, action, severity, actor, targetModel, targetId
+ */
+router.get('/audit-logs', verifyToken, verifyRole(['admin']), async (req, res) => {
+  try {
+    const {
+      page = 1, limit = 50,
+      category, action, severity,
+      actor, targetModel, targetId,
+    } = req.query;
+
+    const q = {};
+    if (category) q.category = category;
+    if (action) q.action = action;
+    if (severity) q.severity = severity;
+    if (actor) q.actor = actor;
+    if (targetModel) q.targetModel = targetModel;
+    if (targetId) q.targetId = targetId;
+
+    const safeLimit = Math.min(200, Math.max(1, Number(limit)));
+    const safePage = Math.max(1, Number(page));
+    const skip = (safePage - 1) * safeLimit;
+
+    const [items, total] = await Promise.all([
+      AuditLog.find(q).sort({ createdAt: -1 }).skip(skip).limit(safeLimit).lean(),
+      AuditLog.countDocuments(q),
+    ]);
+
+    res.status(200).json({
+      page: safePage,
+      limit: safeLimit,
+      total,
+      items,
+    });
+  } catch (err) {
+    res.status(500).json({ message: 'Error fetching audit logs', details: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -151,6 +151,7 @@ const patientRoutes = require('./routes/patientRoutes');
 const wifiCSIRoutes = require('./routes/wifiCSI');
 const activityRecognitionRoutes = require('./routes/activityRecognition');
 const alertsRoutes = require('./routes/alerts');
+const auditLogsRoutes = require('./routes/auditLogs');
 
 app.use('/api/v1/auth', userRoutes);
 app.use('/api/v1/caretaker', caretakerRoutes);
@@ -159,6 +160,7 @@ app.use('/api/v1/patients', patientRoutes);
 app.use('/api/v1/wifi-csi', wifiCSIRoutes);
 app.use('/api/v1/activity-recognition', activityRecognitionRoutes);
 app.use('/api/v1/alerts', alertsRoutes);
+app.use('/api/v1/admin', auditLogsRoutes);
 
 app.use(
   '/swaggerDocs',

--- a/src/utils/audit.js
+++ b/src/utils/audit.js
@@ -1,0 +1,63 @@
+// Non-blocking logger
+const AuditLog = require('../models/AuditLog');
+const Alert = require('../models/Alert'); 
+
+function sanitizeUA(ua) {
+  if (!ua) return null;
+  return String(ua).slice(0, 256);
+}
+
+function ipFromReq(req) {
+  const raw = (req.headers['x-forwarded-for'] || req.ip || '').toString();
+  const first = raw.split(',')[0].trim();
+  return first || null;
+}
+
+function writeAsync(doc) {
+  setImmediate(async () => {
+    try {
+      await AuditLog.create(doc);
+
+      if (doc.severity === 'high' || doc.severity === 'critical') {
+        await Alert.create({
+          user_id: doc.actor || null,
+          alert_type: 'audit_event',
+          message: `[${doc.category}:${doc.action}] ${doc.meta?.reason || ''}`.trim(),
+        });
+      }
+    } catch (err) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn('AuditLog write failed:', err.message);
+      }
+    }
+  });
+}
+
+/**
+ * Public API:
+ * audit.log(req, {
+ *   category: 'auth'|'authorization'|'task'|'patient'|'system',
+ *   action: 'login_failed'|...,
+ *   actor: ObjectId or null,
+ *   targetModel: 'Task'|...,
+ *   targetId: '...',
+ *   severity: 'info'|'low'|'medium'|'high'|'critical',
+ *   meta: { reason: '...', ... }  
+ * });
+ */
+function log(req, payload) {
+  const doc = {
+    actor: payload.actor || null,
+    category: payload.category,
+    action: payload.action,
+    targetModel: payload.targetModel || null,
+    targetId: payload.targetId || null,
+    severity: payload.severity || 'info',
+    ip: payload.ip || ipFromReq(req),
+    userAgent: payload.userAgent || sanitizeUA(req.headers['user-agent']),
+    meta: payload.meta || {},
+  };
+  writeAsync(doc);
+}
+
+module.exports = { log };


### PR DESCRIPTION
## Description

Implements a central, permanent AuditLog system to record sensitive system events for admin auditability and future compliance. The implementation is additive-only and does not modify existing endpoint behavior.

**What’s included**

- New model: src/models/AuditLog.js (permanent; indexed; no TTL).
- Async logger utility: src/utils/audit.js 
- Admin-only listing endpoint: GET /api/v1/admin/audit-logs (pagination + filters).
- Lightweight instrumentation (no behavior changes):
Auth: login_success, login_failed, login_locked, token_invalid, token_expired
RBAC: permission_denied (and permission_check_failed on internal errors)
Tasks: task_created, task_updated, task_deleted

**Files**

New: src/models/AuditLog.js, src/utils/audit.js, src/routes/auditLogs.js 
Modified (audit-only):
- src/middleware/verifyToken.js, src/middleware/verifyRole.js,
- src/controllers/userController.js (login),
- src/controllers/adminController.js (task methods),
- src/server.js (mount /api/v1/admin/audit-logs)

### Todos

- [x] Tested and working locally
- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] Code changes documented
- [x] Requested review from >= 1 devs on the team

### How to test

> Use **Postman** for API calls and **MongoDB Compass** to confirm records.  
> Create a Postman **Environment** with:
> - `baseUrl` = `http://localhost:3000` 
> - `adminToken`, `nurseToken` = *(leave empty; set after login)*

---

### 1) Register users (skip if they already exist)
**POST** `{{baseUrl}}/api/v1/auth/register`  
Headers: `Content-Type: application/json`

**Admin**
```json
{ "fullname": "Admin Audit", "email": "admin.audit@example.com", "password": "AdminPass123!", "role": "admin" }
````

**Nurse**

```json
{ "fullname": "Nurse Audit", "email": "nurse.audit@example.com", "password": "NursePass123!", "role": "nurse" }
```

**Expected:** `201 Created` (or `400` if already exists)

---

### 2) Login and store tokens

**POST** `{{baseUrl}}/api/v1/auth/login`
Headers: `Content-Type: application/json`

**Admin**

```json
{ "email": "admin.audit@example.com", "password": "AdminPass123!" }
```

Tests tab:

```js
pm.environment.set("adminToken", pm.response.json().token);
```

**Nurse**

```json
{ "email": "nurse.audit@example.com", "password": "NursePass123!" }
```

Tests tab:

```js
pm.environment.set("nurseToken", pm.response.json().token);
```

**Expected:** `200 OK` (audit `auth: login_success`)

---

### 3) Auth failures

**Unknown email** → **POST** `/auth/login` with:

```json
{ "email": "nouser@example.com", "password": "SomePass123!" }
```

**Expected:** `400` (audit `auth: login_failed`)

**Wrong password x5 (nurse)** → **POST** `/auth/login` with:

```json
{ "email": "nurse.audit@example.com", "password": "WrongPass!" }
```

**Expected:** multiple `400` (login\_failed) then `400` lock (audit `auth: login_locked`)

---

### 4) Token errors

**Missing/Bad Bearer** → **GET** `{{baseUrl}}/api/v1/alerts` (no/invalid `Authorization`)
**Expected:** `401` or `400` (audit `auth: token_invalid`)

**Invalid signature** → **GET** `.../alerts` with `Authorization: Bearer invalid.invalid.invalid`
**Expected:** `400` (audit `auth: token_invalid`)

---

### 5) RBAC (permission denied)

**Nurse** → **GET** `{{baseUrl}}/api/v1/admin/audit-logs?limit=2`
Header: `Authorization: Bearer {{nurseToken}}`
**Expected:** `403` (audit `authorization: permission_denied`)

---

### 6) Admin: list audit logs

**GET** `{{baseUrl}}/api/v1/admin/audit-logs?limit=10`
Header: `Authorization: Bearer {{adminToken}}`
**Expected:** `200` with `{ page, limit, total, items[] }`

**Filters (examples):**

* `...?category=auth&action=login_failed&limit=5`
* `...?category=authorization&action=permission_denied&limit=5`

---

### 7) (Optional) Task events

If task routes are mounted:

* **POST** `/api/v1/admin/tasks` → expect `201/500` (audit `task_created`)
* **PUT** `/api/v1/admin/tasks/:taskId` → expect `200/404` (audit `task_updated`)
* **DELETE** `/api/v1/admin/tasks/:taskId` → expect `200/404` (audit `task_deleted`)
  Headers: `Authorization: Bearer {{adminToken}}`

---

### 8) Verify in MongoDB Compass

Open **`auditlogs`** collection → sort by **`createdAt` desc**.
You should see:
`auth: login_success, login_failed, login_locked, token_invalid` and
`authorization: permission_denied` 

### Screenshots and/or Gifs

- Run sequence to check endpoints and audit logs

<img width="1184" height="908" alt="image" src="https://github.com/user-attachments/assets/288799ce-62c0-4be7-9e6c-5f07926b68e0" />

- Passed test results summary

<img width="2082" height="1172" alt="image" src="https://github.com/user-attachments/assets/30672689-2cba-4762-9b94-ea309c216ffa" />

- Confirm collection auditlogs on MongoDB

<img width="2846" height="1544" alt="image" src="https://github.com/user-attachments/assets/79543893-a14e-46df-bc52-fd195bb45fd9" />


### Associated MS Planner Tasks

- [Audit Logging System](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/planner.v1.1c7aff73-bd5d-4eaf-844f-a0f0914d35b0_p_obnY9eRGNEGXqjBUOhDWKcgAFWt1?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fv1%2Fplan%2FobnY9eRGNEGXqjBUOhDWKcgAFWt1%2Fview%2Fboard%2Ftask%2FVRn0-3ALd0-e0vyxiOf5Q8gANrw7%22%2C%22channelId%22%3A%2219%3A02e7479536e247c5a85093cf6dcaca4c%40thread.tacv2%22%7D)


### Known Issues

- `auditlogs` are permanent by default. Align on a retention/archival policy (TTL or offline archive) that meets compliance and storage expectations.

- `/api/v1/admin/audit-logs` requires an **admin** role. Ensure role seeding/config is correct in each environment to avoid unexpected 403s.

- Audit writes are async and best-effort. If MongoDB is briefly unavailable, an event may be skipped while the main request still succeeds. If zero-loss is required, plan a queue/stream follow-up.
