### PR TITLE
feat(caretaker): add filters, sorting, pagination

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,0 @@
-BASE_URL=http://localhost:3000
-MONGODB_URI="mongodb://localhost:27017/guardian"
-PORT=3000
-NODE_ENV=development
-JWT_SECRET=your_jwt_secret_key

--- a/src/models/Task.js
+++ b/src/models/Task.js
@@ -6,7 +6,7 @@ const TaskSchema = new mongoose.Schema({
   priority: { type: String, enum: ['low', 'medium', 'high'], default: 'medium'  },
   status: { type: String, enum: ['pending', 'in progress', 'completed'], default: 'pending' },
   patient: { type: mongoose.Schema.Types.ObjectId, ref: 'Patient', required: true },
-  caretaker: { type: mongoose.Schema.Types.ObjectId, ref: 'Caretaker', required: true },
+  caretaker: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   nurse_id: { type: mongoose.Schema.Types.ObjectId, ref: 'User' }, // Assigned nurse
   created_at: { type: Date, default: Date.now },
   report: { type: String }, // Task report provided by caretaker
@@ -17,6 +17,9 @@ TaskSchema.pre('save', function (next) {
   this.updated_at = Date.now();
   next();
 });
+TaskSchema.index({ caretaker: 1, dueDate: 1 });
+TaskSchema.index({ caretaker: 1, priority: 1 });
+TaskSchema.index({ caretaker: 1, status: 1 });
 
 const Task = mongoose.model('Task', TaskSchema);
 

--- a/src/routes/caretakerRoutes.js
+++ b/src/routes/caretakerRoutes.js
@@ -5,5 +5,6 @@ const verifyToken = require('../middleware/verifyToken');
 
 
 router.get('/profile', verifyToken, caretakerController.getProfile);
+router.get('/tasks', verifyToken, caretakerController.getTasks);
 
 module.exports = router;


### PR DESCRIPTION
## *Description*

Fixes incorrect Task.caretaker reference (was pointing to a non-existent Caretaker model).  
Now correctly references the User model, since caretakers are users with the caretaker role.  
Adds GET /api/v1/caretaker/tasks endpoint with filters (filter=urgent, dueDate, status), sorting, and pagination.  
Includes a one-time seed script to insert demo tasks for testing.

---

## *Todos*

- [x] Tested and working locally  
- [x] Code follows the style guidelines of this project  
- [x] I have performed a self-review of my code  
- [x] Code changes documented  
- [x] Requested review from >= 1 devs on the team  

---

## *How to test*

1. Ensure .env contains the MongoDB URI under the MONGODB key:
MONGODB=mongodb+srv://<username>:<password>@cluster0.example.mongodb.net/guardian

2. Run the seed script once to insert demo tasks:
node seedTasksOnly.js

3. Start the backend server:
npm start

4. Test with Postman (use caretakerId explicitly for now):

- Urgent tasks  
/api/v1/caretaker/tasks?filter=urgent&caretakerId=68950c034af33273204ee625  

- Due on/before a date  
/api/v1/caretaker/tasks?dueDate=2025-09-05&caretakerId=68950c034af33273204ee625  

- By status  
/api/v1/caretaker/tasks?status=completed&caretakerId=68950c034af33273204ee625  

- Pagination and sorting  
/api/v1/caretaker/tasks?page=1&limit=2&sort=-created_at&caretakerId=68950c034af33273204ee625  

---

## *Seed Script (seedTasksOnly.js)*

```
require('dotenv').config();
const mongoose = require('mongoose');
const Task = require('./src/models/Task');
mongoose.set('strictQuery', false);

(async () => {
  try {
    if (!process.env.MONGODB) throw new Error('Missing MONGODB in .env');
    await mongoose.connect(process.env.MONGODB);
    console.log('Connected to MongoDB');

    const caretakerId = '68950c034af33273204ee625'; // Alice's User _id
    const patientId   = '68950c034af33273204ee630'; // Elderly Patient One _id

    const now = new Date();
    const tasks = [
      {
        description: 'Check morning vitals',
        dueDate: new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 9, 0),
        priority: 'high',
        status: 'pending',
        patient: patientId,
        caretaker: caretakerId,
        created_at: now,
        updated_at: now
      },
      {
        description: 'Administer medication',
        dueDate: new Date(now.getFullYear(), now.getMonth(), now.getDate() + 3, 10, 0),
        priority: 'medium',
        status: 'in progress',
        patient: patientId,
        caretaker: caretakerId,
        created_at: now,
        updated_at: now
      },
      {
        description: 'Submit daily report',
        dueDate: new Date(now.getFullYear(), now.getMonth(), now.getDate() + 5, 18, 0),
        priority: 'low',
        status: 'completed',
        patient: patientId,
        caretaker: caretakerId,
        created_at: now,
        updated_at: now
      }
    ];

    await Task.insertMany(tasks);
    console.log('Inserted ' + tasks.length + ' tasks for caretaker ' + caretakerId);

    await mongoose.disconnect();
    console.log('Disconnected from MongoDB');
  } catch (err) {
    console.error('Seed error:', err.message);
    process.exit(1);
  }
})();

```
---

## *Screenshots and/or Gifs*

### Postman — urgent filter  
![WhatsApp Image 2025-09-01 at 15 16 50_5af710cb](https://github.com/user-attachments/assets/e7e058b5-9fac-4fc6-9e40-980b7d6d217c)

### Postman — dueDate filter  
![WhatsApp Image 2025-09-01 at 15 17 33_e001f903](https://github.com/user-attachments/assets/1430e9c0-dffb-4d8f-becf-591e00810e3c)

### Postman — status filter  
![WhatsApp Image 2025-09-01 at 15 18 26_14f4c64d](https://github.com/user-attachments/assets/e00788b8-823e-40b7-b205-b7c353f5a05b)

---

## *Known Issues*

- For local testing, caretakerId is passed explicitly. Once JWT includes the user id for the caretaker account, use req.user.id.  
- Seed script is one-time and should be removed after testing.  