### PR TITLE
Feat/patient-delete

### DIFF
--- a/src/controllers/patientController.js
+++ b/src/controllers/patientController.js
@@ -72,7 +72,7 @@ exports.addPatient = async (req, res) => {
  *     summary: Soft delete a patient
  *     description: |
  *       Marks the patient as deleted (non-destructive).
- *       The record remains in the database with `isDeleted` set to `true`.
+ *       The record remains in the database with isDeleted set to true.
  *     tags: [Patient]
  *     security:
  *       - bearerAuth: []
@@ -132,7 +132,6 @@ exports.deletePatient = async (req, res) => {
     return res.status(500).json({ message: 'Error deleting patient', details: err.message });
   }
 };
-
 
 /**
  * @swagger

--- a/src/models/Patient.js
+++ b/src/models/Patient.js
@@ -18,7 +18,6 @@ const PatientSchema = new mongoose.Schema({
   isDeleted: { type: Boolean, default: false, index: true },
   deletedAt: { type: Date },
   deletedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
-
   created_at: { type: Date, default: Date.now },
   updated_at: { type: Date, default: Date.now }
 });

--- a/src/routes/patientRoutes.js
+++ b/src/routes/patientRoutes.js
@@ -6,8 +6,8 @@ const verifyRole = require('../middleware/verifyRole');
 const upload = require('../middleware/multer');
 
 router.post('/add', verifyToken, upload.single('photo'), patientController.addPatient);
-router.post('/assign-nurse', verifyToken, verifyRole(['caretaker']), patientController.assignNurseToPatient);
 router.delete('/:patientId', verifyToken, patientController.deletePatient);
+router.post('/assign-nurse', verifyToken, verifyRole(['caretaker']), patientController.assignNurseToPatient);
 router.get('/assigned-patients', verifyToken, patientController.getAssignedPatients);
 router.get('/', verifyToken, patientController.getPatientDetails);
 


### PR DESCRIPTION
## Description

Adds **soft delete for Patient**:
- Schema: added `isDeleted`, `deletedAt`, `deletedBy` fields.
- Controller: new `deletePatient` handler (soft delete only), handles invalid IDs via CastError (no mongoose import), returns 200/400/404/410 as appropriate.
- Swagger: documented `DELETE /api/v1/patients/{patientId}` (soft delete).
- Routes: wired `DELETE /api/v1/patients/:patientId` (token required; no role guard for now).

### Todos

- [x] Tested and working locally (Postman)
- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] Code changes documented (Swagger)
- [ ] Requested review from >= 1 devs on the team

### How to test

1. **Create a patient** (multipart form-data):
   - `POST /api/v1/patients/add` with `fullname`, `dateOfBirth` (YYYY-MM-DD), `gender`, and optional `profilePhoto` file.
   - Copy `_id` from response.

2. **Soft delete the patient**:
   - `DELETE /api/v1/patients/{_id}`
   - Expect `200 { "message": "Patient deleted", "id": "{_id}" }`

3. **Idempotency check**:
   - Repeat the same DELETE.
   - Expect `410 { "message": "Patient already deleted" }`

### Screenshots and/or Gifs

<img width="1710" height="1107" alt="Screenshot 2025-09-05 at 9 44 42 PM" src="https://github.com/user-attachments/assets/3f25cac5-61ca-433b-bdef-691039855d0f" />


N/A

### Associated MS Planner Tasks

N/A (add if applicable)

### Known Issues

- Soft-deleted patients will still appear on read/list endpoints **until** queries add `{ isDeleted: false }`.
- Delete route currently has **no role guard** by design (only `verifyToken`).
