### PR TITLE
feat: add PUT endpoint to update caretaker profile

### DIFF
--- a/src/routes/caretakerRoutes.js
+++ b/src/routes/caretakerRoutes.js
@@ -6,5 +6,6 @@ const verifyToken = require('../middleware/verifyToken');
 
 router.get('/profile', verifyToken, caretakerController.getProfile);
 router.get('/tasks', verifyToken, caretakerController.getTasks);
+router.put('/profile', verifyToken, caretakerController.updateProfile);
 
 module.exports = router;


### PR DESCRIPTION
## Description

### Before

- There was no endpoint to allow caretakers to **update their profile**.
- Only a `GET /api/v1/caretaker/profile` route existed to **view a caretaker’s profile** using either their ID or email.
- No `PUT` method was implemented to handle profile updates such as changing name, phone, email, gender, or address.

### After

- Added a new `PUT /api/v1/caretaker/profile` endpoint to allow updating a caretaker's profile.
- The update controller:
  - Accepts a `caretakerId` in the request body along with one or more updatable fields.
  - Uses `findByIdAndUpdate()` with validators and returns the updated caretaker profile.
  - Excludes sensitive fields like `password_hash` and `__v`, and populates `role` and `assignedPatients`.
- Successfully tested update functionality using Postman.
- Confirmed that the existing `GET /api/v1/caretaker/profile` endpoint still works as expected using query parameters.

---

### Todos

- [x] Tested and working locally
- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] Code changes documented
- [x] Requested review from >= 1 devs on the team

---

### How to test

1. **PUT request to update caretaker profile**
   - **URL:** `/api/v1/caretaker/profile`
   - **Method:** `PUT`
   - **Headers:**
     - `Authorization: Bearer <JWT-token>`
     - `Content-Type: application/json`
   - **Body Example:**
     ```json
     {
       "caretakerId": "<caretaker-object-id>",
       "fullname": "Updated Name",
       "email": "new.email@example.com",
       "phone": "0400000000",
       "gender": "female",
       "age": 35,
       "address": "123 Main Street"
     }
     ```
   - **Expected:** 200 OK with updated caretaker profile in response.

2. **GET request to fetch updated profile**
   - **URL:** `/api/v1/caretaker/profile?caretakerId=<caretaker-object-id>`
   - **Method:** `GET`
   - **Headers:**
     - `Authorization: Bearer <JWT-token>`
   - **Expected:** JSON showing updated caretaker profile details.

---

### Screenshots and/or Gifs

PUT Request (Update Profile)

<img width="744" height="827" alt="image" src="https://github.com/user-attachments/assets/8e7f70ca-28ee-4e80-82c9-87f594911083" />


### Known Issues

- No role-based restriction is implemented yet (any authenticated user can update any caretaker profile if they have the ID).

