### PR TITLE
Added PUT endpoint to edit patient profile

### DIFF
--- a/src/routes/patientRoutes.js
+++ b/src/routes/patientRoutes.js
@@ -20,6 +20,7 @@ router.delete('/:patientId', verifyToken, patientController.deletePatient);
 // Patients
 router.post('/add', verifyToken, upload.single('profilePhoto'), patientController.addPatient);
 router.delete('/:patientId', verifyToken, patientController.deletePatient);
+router.put('/:patientId', verifyToken, upload.single('profilePhoto'), patientController.updatePatient);
 
 // Assignments
 


### PR DESCRIPTION
## Description

Added a new *PUT /api/v1/patients/:patientId* endpoint to update patient details.  
This allows caretakers (and admins) to edit patient information such as fullname, date of birth, gender, and profile photo.  

### Todos

- [ ✓] Tested and working locally
- [ ✓] Code follows the style guidelines of this project
- [ ✓] I have performed a self-review of my code
- [ ✓] Code changes documented
- [ ✓] Requested review from >= 1 devs on the team

### How to test

Endpoint:  
PUT http://localhost:3000/api/v1/patients/<patientId>

Headers:  
Authorization: Bearer <your_jwt_token>  
Content-Type: application/json  

Body (example JSON):  
{
  "fullname": "Updated Patient Name",
  "dateOfBirth": "1990-05-15",
  "gender": "female"
}

- Replace <patientId> with an existing patient’s MongoDB ObjectId.  
- Use Postman to send the request with a valid JWT.  

### Screenshots and/or Gifs

- [Screenshot Before]  
![bef](https://github.com/user-attachments/assets/34d788b1-456d-4365-a552-d58588c16e96)

- [Screenshot After]  
-
![aft](https://github.com/user-attachments/assets/cf4d2b2f-277f-4543-8121-68bcaa34b8c9)

