### PR TITLE
Reapply "Patient Assignment and Reassignment Implementation"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+.env
+.env.*
+node_modules/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,8 @@ services:
   app:
     container_name: guardian-backend
     build: .
+    env_file:
+      - .env
     ports:
       - "3000:3000"
     volumes:

--- a/src/controllers/adminPatientController.js
+++ b/src/controllers/adminPatientController.js
@@ -436,12 +436,13 @@ exports.reassign = async (req, res) => {
 
       const currentNurseIds = (patient.assignedNurses || []).map(String);
       const nextNurseId = String(nurse._id);
-      currentNurseIds
-        .filter((nId) => nId !== nextNurseId)
-        .forEach((nId) => reverseLinksToRemove.add(nId));
-      if (!currentNurseIds.includes(nextNurseId)) reverseLinksToAdd.add(nextNurseId);
-
-      updates.assignedNurses = [toObjectId(nurse._id)];
+      if (!currentNurseIds.includes(nextNurseId)) {
+        reverseLinksToAdd.add(nextNurseId);
+        updates.assignedNurses = [
+          ...(patient.assignedNurses || []).map((nId) => toObjectId(nId)),
+          toObjectId(nurse._id),
+        ];
+      }
     }
 
     // Assign doctor

--- a/src/controllers/adminPatientController.js
+++ b/src/controllers/adminPatientController.js
@@ -2,12 +2,12 @@
 
 const mongoose = require('mongoose');
 const Patient = require('../models/Patient');
+const User = require('../models/User');
 const { parseStringArray } = require('../utils/arrayUtils');
 const HealthRecord = require('../models/HealthRecord');
 const Task = require('../models/Task');
 const CarePlan = require('../models/CarePlan');
 const EntryReport = require('../models/EntryReport');
-const User = require('../models/User');
 
 const {
   calculateAge,
@@ -37,6 +37,13 @@ const toObjectId = (val) => {
   return new mongoose.Types.ObjectId(String(id));
 };
 
+const sendControllerError = (res, err, fallbackMessage) => {
+  if (err?.status) {
+    return res.status(err.status).json({ message: err.message });
+  }
+  return res.status(500).json({ message: fallbackMessage, details: err.message });
+};
+
 /**
  * Ensures that a staff member (nurse or doctor) belongs to the given organization.
  *
@@ -45,17 +52,16 @@ const toObjectId = (val) => {
  * - If not linked in the user document but present in org.staff, the organization link is auto-fixed.
  * - Otherwise, the user is rejected as not belonging to the organization.
  */
-async function ensureStaffBoundToOrg(userDoc, orgDoc) {
+async function ensureStaffBoundToOrg(userDoc, orgDoc, options = {}) {
   if (!userDoc || !orgDoc) return { ok: false, reason: 'missing' };
   if (assertSameOrg(orgDoc, userDoc)) return { ok: true };
 
   if (isUserInOrg(userDoc, orgDoc) || isUserInOrg({ _id: userDoc._id }, orgDoc)) {
-    const User = require('../models/User');
-    await User.updateOne(
-      { _id: userDoc._id },
-      { $set: { organization: toObjectId(orgDoc._id) } }
-    );
-    return { ok: true, linked: true };
+    if (options.applyLink) {
+      const User = require('../models/User');
+      await User.updateOne({ _id: userDoc._id }, { $set: { organization: toObjectId(orgDoc._id) } });
+    }
+    return { ok: true, linked: Boolean(options.applyLink), needsOrgLink: true };
   }
 
   return { ok: false, reason: 'not_in_staff' };
@@ -184,6 +190,7 @@ exports.createPatient = async (req, res) => {
       nextOfKinName, nextOfKinRelationship, medicalSummary,
       allergies, conditions, notes
     } = req.body || {};
+    const postCommitOrgLinks = new Set();
 
     if (!fullname || !gender || !dateOfBirth || !caretakerId) {
       return res.status(400).json({
@@ -196,24 +203,23 @@ exports.createPatient = async (req, res) => {
       return res.status(404).json({ message: 'Organization not found for admin' });
     }
 
+    const adminOrg = await findAdminOrg(req.user._id, req.query.orgId);
+    if (!adminOrg) return res.status(404).json({ message: 'Organization not found for admin' });
+
+    // caretaker must be valid and have role caretaker
     const caretaker = await ensureUserWithRole(toId(caretakerId), 'caretaker');
     if (!caretaker) {
       return res.status(400).json({ message: 'caretakerId must be a caretaker' });
     }
 
-    const caretakerLinkResult = await linkCaretakerToOrgIfFreelance(caretaker, org);
-
-    if (caretakerLinkResult?.movedFromOtherOrg) {
-      return res.status(400).json({
-        message: 'Caretaker belongs to another organization'
-      });
-    }
-
-    const refreshedCaretaker = await ensureUserWithRole(toId(caretakerId), 'caretaker');
-    if (!refreshedCaretaker || String(refreshedCaretaker.organization) !== String(org._id)) {
-      return res.status(400).json({
-        message: 'Caretaker must belong to this organization'
-      });
+    let orgId = adminOrg._id;
+    if (caretaker.organization) {
+      if (!assertSameOrg(adminOrg, caretaker)) {
+        return res.status(400).json({ message: 'Caretaker belongs to another organization' });
+      }
+      orgId = caretaker.organization;
+    } else {
+      postCommitOrgLinks.add(String(caretaker._id));
     }
 
     let nurse = null;
@@ -223,14 +229,10 @@ exports.createPatient = async (req, res) => {
         return res.status(400).json({ message: 'nurseId must be a nurse' });
       }
 
-      const ensured = await ensureStaffBoundToOrg(nd, org);
-      if (!ensured.ok) {
-        return res.status(400).json({
-          message: 'nurseId must be a nurse in this organization'
-        });
-      }
-
-      nurse = await ensureUserWithRole(toId(nurseId), 'nurse');
+      const ensured = await ensureStaffBoundToOrg(nd, adminOrg);
+      if (!ensured.ok) return res.status(400).json({ message: 'nurseId must be a nurse in this org' });
+      if (ensured.needsOrgLink) postCommitOrgLinks.add(String(nd._id));
+      nurse = nd;
     }
 
     let doctor = null;
@@ -240,14 +242,10 @@ exports.createPatient = async (req, res) => {
         return res.status(400).json({ message: 'doctorId must be a doctor' });
       }
 
-      const ensured = await ensureStaffBoundToOrg(dd, org);
-      if (!ensured.ok) {
-        return res.status(400).json({
-          message: 'doctorId must be a doctor in this organization'
-        });
-      }
-
-      doctor = await ensureUserWithRole(toId(doctorId), 'doctor');
+      const ensured = await ensureStaffBoundToOrg(dd, adminOrg);
+      if (!ensured.ok) return res.status(400).json({ message: 'doctorId must be a doctor in this org' });
+      if (ensured.needsOrgLink) postCommitOrgLinks.add(String(dd._id));
+      doctor = dd;
     }
 
     const patient = await Patient.create({
@@ -272,19 +270,23 @@ exports.createPatient = async (req, res) => {
       isDeleted: false
     });
 
-    await addAssignedPatient(refreshedCaretaker._id, patient._id);
-    if (nurse) await addAssignedPatient(nurse._id, patient._id);
-    if (doctor) await addAssignedPatient(doctor._id, patient._id);
+    const postCommitOps = [];
+    for (const userId of postCommitOrgLinks) {
+      postCommitOps.push(
+        User.updateOne({ _id: userId }, { $set: { organization: toObjectId(adminOrg._id) } })
+      );
+    }
+    postCommitOps.push(addAssignedPatient(caretaker._id, patient._id));
+    if (nurse) postCommitOps.push(addAssignedPatient(nurse._id, patient._id));
+    if (doctor) postCommitOps.push(addAssignedPatient(doctor._id, patient._id));
+    await Promise.all(postCommitOps);
 
     return res.status(201).json({
       message: 'Patient created',
       patient: { ...patient.toObject(), age: calculateAge(patient.dateOfBirth) }
     });
   } catch (err) {
-    return res.status(500).json({
-      message: 'Error creating patient',
-      details: err.message
-    });
+    return sendControllerError(res, err, 'Error creating patient');
   }
 };
 
@@ -412,64 +414,118 @@ exports.reassign = async (req, res) => {
 
     const { nurseId, caretakerId, doctorId } = req.body || {};
     const updates = {};
+    const reverseLinksToAdd = new Set();
+    const reverseLinksToRemove = new Set();
+    const postCommitOrgLinks = new Set();
+
+    if (!nurseId && !caretakerId && !doctorId) {
+      return res.status(400).json({
+        message: 'At least one of nurseId, doctorId, or caretakerId is required'
+      });
+    }
 
     // Assign nurse
     if (nurseId) {
       const nurse = await ensureUserWithRole(toId(nurseId), 'nurse');
-      if (!nurse) return res.status(400).json({ message: 'nurseId must be a nurse' });
+      if (!nurse) {
+        return res.status(400).json({ message: 'nurseId must be a nurse' });
+      }
 
       const ensured = await ensureStaffBoundToOrg(nurse, org);
       if (!ensured.ok) {
-        return res.status(400).json({ message: 'nurseId must be a nurse in this org' });
+        return res.status(400).json({
+          message: 'nurseId must be a nurse in this org'
+        });
       }
+      if (ensured.needsOrgLink) postCommitOrgLinks.add(String(nurse._id));
 
-      await Patient.updateOne(
-        { _id: id },
-        { $addToSet: { assignedNurses: toObjectId(nurse._id) } }
-      );
-      await addAssignedPatient(nurse._id, patient._id);
+      const currentNurseIds = (patient.assignedNurses || []).map(String);
+      const nextNurseId = String(nurse._id);
+      currentNurseIds
+        .filter((nId) => nId !== nextNurseId)
+        .forEach((nId) => reverseLinksToRemove.add(nId));
+      if (!currentNurseIds.includes(nextNurseId)) reverseLinksToAdd.add(nextNurseId);
+
+      updates.assignedNurses = [toObjectId(nurse._id)];
     }
 
     // Assign doctor
     if (doctorId) {
       const doctor = await ensureUserWithRole(toId(doctorId), 'doctor');
-      if (!doctor) return res.status(400).json({ message: 'doctorId must be a doctor' });
+      if (!doctor) {
+        return res.status(400).json({ message: 'doctorId must be a doctor' });
+      }
 
       const ensured = await ensureStaffBoundToOrg(doctor, org);
       if (!ensured.ok) {
-        return res.status(400).json({ message: 'doctorId must be a doctor in this org' });
+        return res.status(400).json({
+          message: 'doctorId must be a doctor in this org'
+        });
       }
+      if (ensured.needsOrgLink) postCommitOrgLinks.add(String(doctor._id));
 
       if (patient.assignedDoctor && String(patient.assignedDoctor) !== String(doctor._id)) {
-        await removeAssignedPatient(patient.assignedDoctor, patient._id);
+        reverseLinksToRemove.add(String(patient.assignedDoctor));
+      }
+      if (String(patient.assignedDoctor || '') !== String(doctor._id)) {
+        reverseLinksToAdd.add(String(doctor._id));
       }
 
       updates.assignedDoctor = toObjectId(doctor._id);
-      await addAssignedPatient(doctor._id, patient._id);
     }
 
     // Assign caretaker
     if (caretakerId) {
       const caretaker = await ensureUserWithRole(toId(caretakerId), 'caretaker');
-      if (!caretaker) return res.status(400).json({ message: 'caretakerId must be a caretaker' });
-
-      const linkResult = await linkCaretakerToOrgIfFreelance(caretaker, org);
-      if (linkResult.movedFromOtherOrg) {
-        return res.status(400).json({ message: 'Caretaker belongs to another organization' });
+      if (!caretaker) {
+        return res.status(400).json({ message: 'caretakerId must be a caretaker' });
       }
 
-      if (patient.caretaker && String(patient.caretaker) !== String(caretaker._id)) {
-        await removeAssignedPatient(patient.caretaker, patient._id);
-      }
+      const caretakerUnchanged =
+        patient.caretaker && String(patient.caretaker) === String(caretaker._id);
 
-      updates.caretaker = toObjectId(caretaker._id);
-      await addAssignedPatient(caretaker._id, patient._id);
+      if (!caretakerUnchanged) {
+        const linkResult = await linkCaretakerToOrgIfFreelance(caretaker, org, { applyLink: false });
+        if (linkResult.movedFromOtherOrg) {
+          return res.status(400).json({
+            message: 'Caretaker belongs to another organization'
+          });
+        }
+        if (linkResult.needsOrgLink) postCommitOrgLinks.add(String(caretaker._id));
+        if (patient.caretaker) reverseLinksToRemove.add(String(patient.caretaker));
+        reverseLinksToAdd.add(String(caretaker._id));
+
+        updates.caretaker = toObjectId(caretaker._id);
+      }
+    }
+
+    if (!Object.keys(updates).length) {
+      return res.status(200).json({
+        message: 'No assignment changes applied',
+        data: {
+          patientId: patient._id,
+        }
+      });
     }
 
     const updated = await Patient.findByIdAndUpdate(id, { $set: updates }, { new: true })
       .populate('caretaker', 'fullname email')
       .populate('assignedNurses', 'fullname email')
       .populate('assignedDoctor', 'fullname email');
+
+    const postCommitOps = [];
+    for (const userId of postCommitOrgLinks) {
+      postCommitOps.push(
+        User.updateOne({ _id: userId }, { $set: { organization: toObjectId(org._id) } })
+      );
+    }
+    for (const userId of reverseLinksToRemove) {
+      postCommitOps.push(removeAssignedPatient(userId, patient._id));
+    }
+    for (const userId of reverseLinksToAdd) {
+      postCommitOps.push(addAssignedPatient(userId, patient._id));
+    }
+    await Promise.all(postCommitOps);
 
     const age = calculateAge(updated?.dateOfBirth);
 
@@ -478,7 +534,7 @@ exports.reassign = async (req, res) => {
       patient: { ...updated.toObject(), age }
     });
   } catch (err) {
-    return res.status(500).json({ message: 'Error reassigning', details: err.message });
+    return sendControllerError(res, err, 'Error reassigning');
   }
 };
 
@@ -681,7 +737,7 @@ exports.listPatients = async (req, res) => {
       pagination: { total, page: p, pages: Math.ceil(total / l), limit: l },
     });
   } catch (err) {
-    return res.status(500).json({ message: 'Error listing patients', details: err.message });
+    return sendControllerError(res, err, 'Error listing patients');
   }
 };
 
@@ -909,7 +965,7 @@ exports.patientOverview = async (req, res) => {
       taskCompletionRate,
     });
   } catch (err) {
-    return res.status(500).json({ message: 'Error fetching patient overview', details: err.message });
+    return sendControllerError(res, err, 'Error fetching patient overview');
   }
 };
 
@@ -981,6 +1037,6 @@ exports.deactivatePatient = async (req, res) => {
 
     return res.status(200).json({ message: 'Patient deactivated' });
   } catch (err) {
-    return res.status(500).json({ message: 'Error deactivating patient', details: err.message });
+    return sendControllerError(res, err, 'Error deactivating patient');
   }
 };

--- a/src/controllers/adminPatientController.js
+++ b/src/controllers/adminPatientController.js
@@ -198,11 +198,6 @@ exports.createPatient = async (req, res) => {
       });
     }
 
-    const org = await findAdminOrg(req.user._id, req.query.orgId);
-    if (!org) {
-      return res.status(404).json({ message: 'Organization not found for admin' });
-    }
-
     const adminOrg = await findAdminOrg(req.user._id, req.query.orgId);
     if (!adminOrg) return res.status(404).json({ message: 'Organization not found for admin' });
 
@@ -252,8 +247,8 @@ exports.createPatient = async (req, res) => {
       fullname,
       dateOfBirth: new Date(dateOfBirth),
       gender,
-      organization: org._id,
-      caretaker: refreshedCaretaker._id,
+      organization: orgId,
+      caretaker: caretaker._id,
       assignedNurses: nurse ? [nurse._id] : [],
       assignedDoctor: doctor ? doctor._id : null,
       profilePhoto: profilePhoto || image || null,
@@ -293,7 +288,7 @@ exports.createPatient = async (req, res) => {
 /* ---------------------------------------------------------------------- */
 /**
  * @swagger
- * /api/v1/admin/patients/{id}/assign:
+ * /api/v1/admin/patients/{id}/reassign:
  *   put:
  *     summary: Update patient staff assignments
  *     description: Assigns or reassigns a caretaker, nurse, or doctor to an existing patient. At least one of `nurseId`, `doctorId`, or `caretakerId` should be provided.

--- a/src/controllers/patientController.js
+++ b/src/controllers/patientController.js
@@ -5,7 +5,7 @@ const notifyRules = require('../services/notifyRules');
 const Role = require('../models/Role');
 const { parseStringArray } = require('../utils/arrayUtils');
 
-/**
+/*
  * Restricts independent patient-management routes for approved organization-linked
  * nurses and caretakers. These users must use the organization-based workflow.
  */
@@ -37,6 +37,7 @@ async function blockIndependentPatientWorkForApprovedOrgMember(userId) {
  *     description: Endpoints for independent patient management
  *   - name: EntryReport
  *     description: Endpoints for patient activity and entry reporting
+ */
 
 /**
  * @swagger

--- a/src/routes/adminPatientRoutes.js
+++ b/src/routes/adminPatientRoutes.js
@@ -13,7 +13,7 @@ router.use(verifyToken, verifyRole(['admin']));
 router.post('/patients', adminPatientController.createPatient);
 
 // reassign nurse / caretaker / doctor for a patient
-router.put('/patients/:id/assign', adminPatientController.reassign);
+router.put('/patients/:id/reassign', adminPatientController.reassign);
 
 // list patients in org (with search + pagination + active filter)
 router.get('/patients', adminPatientController.listPatients);

--- a/src/services/orgService.js
+++ b/src/services/orgService.js
@@ -37,7 +37,7 @@ const userHasOrgField = () => Boolean(User?.schema?.path?.('organization'));
 
 /* -------------------------- Org resolution (admin) ------------------------ */
 
-// find org for admin → by query orgId or by staff/createdBy
+// find org for admin -> by query orgId or by staff/createdBy
 async function resolveAdminOrg({ adminUserId, orgIdFromQuery }) {
   if (!adminUserId) {
     const e = new Error('resolveAdminOrg: adminUserId is required');
@@ -62,10 +62,7 @@ async function resolveAdminOrg({ adminUserId, orgIdFromQuery }) {
     return org;
   }
 
-  return org;
-}
-
-  // fallback → find org where admin is creator or staff
+  // fallback -> find org where admin is creator or staff
   const org = await Organization.findOne({
     $or: [{ createdBy: adminUserId }, { staff: adminUserId }],
   });
@@ -114,7 +111,7 @@ function isUserInOrg(userDoc, orgDoc) {
   return Array.isArray(orgDoc.staff) && orgDoc.staff.some((id) => idsEqual(id, userId));
 }
 
-// if caretaker has no org → link them to this org
+// if caretaker has no org -> link them to this org
 async function linkCaretakerToOrgIfFreelance(caretakerDoc, orgDoc, options = {}) {
   if (!caretakerDoc) {
     const e = new Error('linkCaretakerToOrgIfFreelance: caretaker is required');

--- a/src/services/orgService.js
+++ b/src/services/orgService.js
@@ -11,16 +11,16 @@ const idsEqual = (a, b) => a && b && String(a) === String(b);
 function toId(x) {
   if (!x) return undefined;
 
-  // first handle mongoose docs / plain objects safely
+  // mongoose doc or plain object
   if (typeof x === 'object') {
     const v = x._id ?? x.id ?? x.orgId ?? x.userId;
     if (mongoose.isValidObjectId(v)) return String(v);
   }
 
-  // then handle raw ObjectId / raw 24-hex string
+  // already valid ObjectId / 24-hex
   if (mongoose.isValidObjectId(x)) return String(x);
 
-  // string representations like ObjectId("...")
+  // string representations (ObjectId("..."), new ObjectId("..."), raw hex)
   if (typeof x === 'string') {
     const m = x.match(
       /new\s+ObjectId\(["']([0-9a-fA-F]{24})["']\)|ObjectId\(["']([0-9a-fA-F]{24})["']\)|([0-9a-fA-F]{24})/
@@ -47,18 +47,19 @@ async function resolveAdminOrg({ adminUserId, orgIdFromQuery }) {
 
   // if orgId is explicitly passed
   if (orgIdFromQuery) {
-  const id = toId(orgIdFromQuery);
-  const org = id
-    ? await Organization.findOne({
-        _id: id,
-        $or: [{ createdBy: adminUserId }, { staff: adminUserId }],
-      })
-    : null;
-
-  if (!org) {
-    const e = new Error('Organization not found for admin');
-    e.status = 404;
-    throw e;
+    const id = toId(orgIdFromQuery);
+    const org = id
+      ? await Organization.findOne({
+          _id: id,
+          $or: [{ createdBy: adminUserId }, { staff: adminUserId }],
+        })
+      : null;
+    if (!org) {
+      const e = new Error('Organization not found for admin');
+      e.status = 404;
+      throw e;
+    }
+    return org;
   }
 
   return org;
@@ -114,15 +115,20 @@ function isUserInOrg(userDoc, orgDoc) {
 }
 
 // if caretaker has no org → link them to this org
-async function linkCaretakerToOrgIfFreelance(caretakerDoc, orgDoc) {
-  if (!caretakerDoc || !orgDoc) {
-    const e = new Error('caretaker and org are required');
+async function linkCaretakerToOrgIfFreelance(caretakerDoc, orgDoc, options = {}) {
+  if (!caretakerDoc) {
+    const e = new Error('linkCaretakerToOrgIfFreelance: caretaker is required');
+    e.status = 400;
+    throw e;
+  }
+  if (!orgDoc) {
+    const e = new Error('linkCaretakerToOrgIfFreelance: org is required');
     e.status = 400;
     throw e;
   }
 
   if (!userHasOrgField()) {
-    return { linked: false, alreadyInOrg: false, movedFromOtherOrg: false };
+    return { linked: false, alreadyInOrg: false, movedFromOtherOrg: false, needsOrgLink: false };
   }
 
   const orgId = toId(orgDoc);
@@ -130,28 +136,24 @@ async function linkCaretakerToOrgIfFreelance(caretakerDoc, orgDoc) {
 
   // no org yet -> bind now
   if (!currentOrgId) {
-    await User.updateOne(
-      { _id: caretakerDoc._id },
-      { $set: { organization: orgId } }
-    );
-    return { linked: true, alreadyInOrg: false, movedFromOtherOrg: false };
+    if (options.applyLink) {
+      await User.updateOne({ _id: caretakerDoc._id }, { $set: { organization: orgId } });
+    }
+    return {
+      linked: Boolean(options.applyLink),
+      alreadyInOrg: false,
+      movedFromOtherOrg: false,
+      needsOrgLink: true,
+    };
   }
 
   // already same org
   if (idsEqual(currentOrgId, orgId)) {
-    return { linked: false, alreadyInOrg: true, movedFromOtherOrg: false };
+    return { linked: false, alreadyInOrg: true, movedFromOtherOrg: false, needsOrgLink: false };
   }
 
-  // recovery: if user is actually in org.staff, sync organization instead of rejecting
-  if (Array.isArray(orgDoc.staff) && orgDoc.staff.some(id => idsEqual(id, caretakerDoc._id))) {
-    await User.updateOne(
-      { _id: caretakerDoc._id },
-      { $set: { organization: orgId } }
-    );
-    return { linked: true, alreadyInOrg: false, movedFromOtherOrg: false, repaired: true };
-  }
-
-  return { linked: false, alreadyInOrg: false, movedFromOtherOrg: true };
+  // caretaker already belongs elsewhere
+  return { linked: false, alreadyInOrg: false, movedFromOtherOrg: true, needsOrgLink: false };
 }
 
 /* ------------------------- Staff add/remove helpers ------------------------ */

--- a/src/test/adminPatientReassign.cjs
+++ b/src/test/adminPatientReassign.cjs
@@ -1,0 +1,508 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'gmproject';
+
+const chai = require('chai');
+const mongoose = require('mongoose');
+
+const adminPatientController = require('../controllers/adminPatientController');
+const Organization = require('../models/Organization');
+const Patient = require('../models/Patient');
+const Role = require('../models/Role');
+const User = require('../models/User');
+
+const { expect } = chai;
+
+const MONGODB_URI =
+  process.env.MONGODB_URI || 'mongodb://admin:password@localhost:27018/guardian_test?authSource=admin';
+
+function makeRes() {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+async function createRoleMap() {
+  const roles = await Role.create([
+    { name: 'admin' },
+    { name: 'nurse' },
+    { name: 'caretaker' },
+    { name: 'doctor' },
+  ]);
+
+  return roles.reduce((acc, role) => {
+    acc[role.name] = role._id;
+    return acc;
+  }, {});
+}
+
+async function createUser({ fullname, email, role, organization }) {
+  return User.create({
+    fullname,
+    email,
+    password_hash: 'Password123!',
+    role,
+    organization,
+  });
+}
+
+async function buildFixture() {
+  const roleIds = await createRoleMap();
+
+  const admin = await createUser({
+    fullname: 'Admin User',
+    email: 'admin@test.local',
+    role: roleIds.admin,
+  });
+
+  const organization = await Organization.create({
+    name: 'Guardian Test Org',
+    description: 'Test organization',
+    active: true,
+    createdBy: admin._id,
+    staff: [admin._id],
+  });
+
+  const [oldCaretaker, newCaretaker, oldNurse, newNurse, oldDoctor, newDoctor] = await Promise.all([
+    createUser({
+      fullname: 'Old Caretaker',
+      email: 'old-caretaker@test.local',
+      role: roleIds.caretaker,
+      organization: organization._id,
+    }),
+    createUser({
+      fullname: 'New Caretaker',
+      email: 'new-caretaker@test.local',
+      role: roleIds.caretaker,
+      organization: organization._id,
+    }),
+    createUser({
+      fullname: 'Old Nurse',
+      email: 'old-nurse@test.local',
+      role: roleIds.nurse,
+      organization: organization._id,
+    }),
+    createUser({
+      fullname: 'New Nurse',
+      email: 'new-nurse@test.local',
+      role: roleIds.nurse,
+      organization: organization._id,
+    }),
+    createUser({
+      fullname: 'Old Doctor',
+      email: 'old-doctor@test.local',
+      role: roleIds.doctor,
+      organization: organization._id,
+    }),
+    createUser({
+      fullname: 'New Doctor',
+      email: 'new-doctor@test.local',
+      role: roleIds.doctor,
+      organization: organization._id,
+    }),
+  ]);
+
+  await Organization.updateOne(
+    { _id: organization._id },
+    {
+      $addToSet: {
+        staff: { $each: [oldNurse._id, newNurse._id, oldDoctor._id, newDoctor._id] },
+      },
+    }
+  );
+
+  const patient = await Patient.create({
+    fullname: 'Patient Zero',
+    gender: 'male',
+    dateOfBirth: new Date('1980-05-17'),
+    organization: organization._id,
+    caretaker: oldCaretaker._id,
+    assignedNurses: [oldNurse._id],
+    assignedDoctor: oldDoctor._id,
+    dateOfAdmitting: new Date('2026-03-26'),
+  });
+
+  await Promise.all([
+    User.updateOne({ _id: oldCaretaker._id }, { $addToSet: { assignedPatients: patient._id } }),
+    User.updateOne({ _id: oldNurse._id }, { $addToSet: { assignedPatients: patient._id } }),
+    User.updateOne({ _id: oldDoctor._id }, { $addToSet: { assignedPatients: patient._id } }),
+  ]);
+
+  return {
+    admin,
+    organization,
+    patient,
+    oldCaretaker,
+    newCaretaker,
+    oldNurse,
+    newNurse,
+    oldDoctor,
+    newDoctor,
+  };
+}
+
+async function buildSecondOrg(roleIds) {
+  const otherAdmin = await createUser({
+    fullname: 'Other Admin',
+    email: 'other-admin@test.local',
+    role: roleIds.admin,
+  });
+
+  const otherOrganization = await Organization.create({
+    name: 'Other Test Org',
+    description: 'Second organization',
+    active: true,
+    createdBy: otherAdmin._id,
+    staff: [otherAdmin._id],
+  });
+
+  const [otherCaretaker, otherNurse, otherDoctor] = await Promise.all([
+    createUser({
+      fullname: 'Other Caretaker',
+      email: 'other-caretaker@test.local',
+      role: roleIds.caretaker,
+      organization: otherOrganization._id,
+    }),
+    createUser({
+      fullname: 'Other Nurse',
+      email: 'other-nurse@test.local',
+      role: roleIds.nurse,
+      organization: otherOrganization._id,
+    }),
+    createUser({
+      fullname: 'Other Doctor',
+      email: 'other-doctor@test.local',
+      role: roleIds.doctor,
+      organization: otherOrganization._id,
+    }),
+  ]);
+
+  await Organization.updateOne(
+    { _id: otherOrganization._id },
+    {
+      $addToSet: {
+        staff: { $each: [otherNurse._id, otherDoctor._id] },
+      },
+    }
+  );
+
+  return {
+    otherAdmin,
+    otherOrganization,
+    otherCaretaker,
+    otherNurse,
+    otherDoctor,
+  };
+}
+
+describe('admin patient reassign flow', function () {
+  this.timeout(15000);
+
+  before(async () => {
+    await mongoose.connect(MONGODB_URI, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+      serverSelectionTimeoutMS: 5000,
+    });
+  });
+
+  beforeEach(async () => {
+    await mongoose.connection.db.dropDatabase();
+  });
+
+  after(async () => {
+    await mongoose.disconnect();
+  });
+
+  it('reassigns caretaker, nurse, and doctor in the same org and removes old reverse assignments', async () => {
+    const fixture = await buildFixture();
+    const req = {
+      params: { id: String(fixture.patient._id) },
+      query: { orgId: String(fixture.organization._id) },
+      body: {
+        caretakerId: String(fixture.newCaretaker._id),
+        nurseId: String(fixture.newNurse._id),
+        doctorId: String(fixture.newDoctor._id),
+      },
+      user: { _id: String(fixture.admin._id) },
+    };
+    const res = makeRes();
+
+    await adminPatientController.reassign(req, res);
+
+    expect(res.statusCode).to.equal(200);
+    expect(res.body.message).to.equal('Assignments updated');
+    expect(String(res.body.patient.caretaker._id)).to.equal(String(fixture.newCaretaker._id));
+    expect(String(res.body.patient.assignedDoctor._id)).to.equal(String(fixture.newDoctor._id));
+    expect(res.body.patient.assignedNurses).to.have.length(1);
+    expect(String(res.body.patient.assignedNurses[0]._id)).to.equal(String(fixture.newNurse._id));
+
+    const updatedPatient = await Patient.findById(fixture.patient._id).lean();
+    expect(String(updatedPatient.caretaker)).to.equal(String(fixture.newCaretaker._id));
+    expect(String(updatedPatient.assignedDoctor)).to.equal(String(fixture.newDoctor._id));
+    expect(updatedPatient.assignedNurses.map(String)).to.deep.equal([String(fixture.newNurse._id)]);
+
+    const [
+      oldCaretaker,
+      newCaretaker,
+      oldNurse,
+      newNurse,
+      oldDoctor,
+      newDoctor,
+    ] = await Promise.all([
+      User.findById(fixture.oldCaretaker._id).lean(),
+      User.findById(fixture.newCaretaker._id).lean(),
+      User.findById(fixture.oldNurse._id).lean(),
+      User.findById(fixture.newNurse._id).lean(),
+      User.findById(fixture.oldDoctor._id).lean(),
+      User.findById(fixture.newDoctor._id).lean(),
+    ]);
+
+    expect((oldCaretaker.assignedPatients || []).map(String)).to.not.include(String(fixture.patient._id));
+    expect((oldNurse.assignedPatients || []).map(String)).to.not.include(String(fixture.patient._id));
+    expect((oldDoctor.assignedPatients || []).map(String)).to.not.include(String(fixture.patient._id));
+
+    expect((newCaretaker.assignedPatients || []).map(String)).to.include(String(fixture.patient._id));
+    expect((newNurse.assignedPatients || []).map(String)).to.include(String(fixture.patient._id));
+    expect((newDoctor.assignedPatients || []).map(String)).to.include(String(fixture.patient._id));
+  });
+
+  it('still updates nurse and doctor when caretaker is unchanged', async () => {
+    const fixture = await buildFixture();
+    const req = {
+      params: { id: String(fixture.patient._id) },
+      query: { orgId: String(fixture.organization._id) },
+      body: {
+        caretakerId: String(fixture.oldCaretaker._id),
+        nurseId: String(fixture.newNurse._id),
+        doctorId: String(fixture.newDoctor._id),
+      },
+      user: { _id: String(fixture.admin._id) },
+    };
+    const res = makeRes();
+
+    await adminPatientController.reassign(req, res);
+
+    expect(res.statusCode).to.equal(200);
+    expect(res.body.message).to.equal('Assignments updated');
+    expect(String(res.body.patient.caretaker._id)).to.equal(String(fixture.oldCaretaker._id));
+    expect(String(res.body.patient.assignedDoctor._id)).to.equal(String(fixture.newDoctor._id));
+    expect(res.body.patient.assignedNurses).to.have.length(1);
+    expect(String(res.body.patient.assignedNurses[0]._id)).to.equal(String(fixture.newNurse._id));
+
+    const [oldNurse, newNurse, oldDoctor, newDoctor] = await Promise.all([
+      User.findById(fixture.oldNurse._id).lean(),
+      User.findById(fixture.newNurse._id).lean(),
+      User.findById(fixture.oldDoctor._id).lean(),
+      User.findById(fixture.newDoctor._id).lean(),
+    ]);
+
+    expect((oldNurse.assignedPatients || []).map(String)).to.not.include(String(fixture.patient._id));
+    expect((oldDoctor.assignedPatients || []).map(String)).to.not.include(String(fixture.patient._id));
+    expect((newNurse.assignedPatients || []).map(String)).to.include(String(fixture.patient._id));
+    expect((newDoctor.assignedPatients || []).map(String)).to.include(String(fixture.patient._id));
+  });
+
+  it('rejects assignments when the provided ids do not match the expected roles', async () => {
+    const fixture = await buildFixture();
+    const req = {
+      params: { id: String(fixture.patient._id) },
+      query: { orgId: String(fixture.organization._id) },
+      body: {
+        nurseId: String(fixture.newDoctor._id),
+      },
+      user: { _id: String(fixture.admin._id) },
+    };
+    const res = makeRes();
+
+    await adminPatientController.reassign(req, res);
+
+    expect(res.statusCode).to.equal(400);
+    expect(res.body).to.deep.equal({ message: 'nurseId must be a nurse' });
+  });
+
+  it('returns 400 when reassign is called with an empty body', async () => {
+    const fixture = await buildFixture();
+    const req = {
+      params: { id: String(fixture.patient._id) },
+      query: { orgId: String(fixture.organization._id) },
+      body: {},
+      user: { _id: String(fixture.admin._id) },
+    };
+    const res = makeRes();
+
+    await adminPatientController.reassign(req, res);
+
+    expect(res.statusCode).to.equal(400);
+    expect(res.body).to.deep.equal({
+      message: 'At least one of nurseId, doctorId, or caretakerId is required'
+    });
+  });
+
+  it('does not mutate reverse links when reassign fails after partial validation', async () => {
+    const fixture = await buildFixture();
+    const req = {
+      params: { id: String(fixture.patient._id) },
+      query: { orgId: String(fixture.organization._id) },
+      body: {
+        nurseId: String(fixture.newNurse._id),
+        doctorId: String(fixture.newCaretaker._id),
+      },
+      user: { _id: String(fixture.admin._id) },
+    };
+    const res = makeRes();
+
+    await adminPatientController.reassign(req, res);
+
+    expect(res.statusCode).to.equal(400);
+    expect(res.body).to.deep.equal({ message: 'doctorId must be a doctor' });
+
+    const [patient, oldNurse, newNurse, oldDoctor] = await Promise.all([
+      Patient.findById(fixture.patient._id).lean(),
+      User.findById(fixture.oldNurse._id).lean(),
+      User.findById(fixture.newNurse._id).lean(),
+      User.findById(fixture.oldDoctor._id).lean(),
+    ]);
+
+    expect(patient.assignedNurses.map(String)).to.deep.equal([String(fixture.oldNurse._id)]);
+    expect(String(patient.assignedDoctor)).to.equal(String(fixture.oldDoctor._id));
+    expect((oldNurse.assignedPatients || []).map(String)).to.include(String(fixture.patient._id));
+    expect((newNurse.assignedPatients || []).map(String)).to.not.include(String(fixture.patient._id));
+    expect((oldDoctor.assignedPatients || []).map(String)).to.include(String(fixture.patient._id));
+  });
+
+  it('blocks cross-org reassignment attempts for staff and caretakers', async () => {
+    const fixture = await buildFixture();
+    const roleIds = await Role.find({}).lean().then((roles) => roles.reduce((acc, role) => {
+      acc[role.name] = role._id;
+      return acc;
+    }, {}));
+    const otherOrg = await buildSecondOrg(roleIds);
+
+    const doctorReq = {
+      params: { id: String(fixture.patient._id) },
+      query: { orgId: String(fixture.organization._id) },
+      body: {
+        doctorId: String(otherOrg.otherDoctor._id),
+      },
+      user: { _id: String(fixture.admin._id) },
+    };
+    const doctorRes = makeRes();
+
+    await adminPatientController.reassign(doctorReq, doctorRes);
+
+    expect(doctorRes.statusCode).to.equal(400);
+    expect(doctorRes.body).to.deep.equal({ message: 'doctorId must be a doctor in this org' });
+
+    const caretakerReq = {
+      params: { id: String(fixture.patient._id) },
+      query: { orgId: String(fixture.organization._id) },
+      body: {
+        caretakerId: String(otherOrg.otherCaretaker._id),
+      },
+      user: { _id: String(fixture.admin._id) },
+    };
+    const caretakerRes = makeRes();
+
+    await adminPatientController.reassign(caretakerReq, caretakerRes);
+
+    expect(caretakerRes.statusCode).to.equal(400);
+    expect(caretakerRes.body).to.deep.equal({ message: 'Caretaker belongs to another organization' });
+  });
+
+  it('blocks create-patient attempts when the caretaker belongs to another org', async () => {
+    const fixture = await buildFixture();
+    const roleIds = await Role.find({}).lean().then((roles) => roles.reduce((acc, role) => {
+      acc[role.name] = role._id;
+      return acc;
+    }, {}));
+    const otherOrg = await buildSecondOrg(roleIds);
+
+    const req = {
+      query: { orgId: String(fixture.organization._id) },
+      body: {
+        fullname: 'Blocked Patient',
+        gender: 'male',
+        dateOfBirth: '1985-01-01',
+        caretakerId: String(otherOrg.otherCaretaker._id),
+      },
+      user: { _id: String(fixture.admin._id) },
+    };
+    const res = makeRes();
+
+    await adminPatientController.createPatient(req, res);
+
+    expect(res.statusCode).to.equal(400);
+    expect(res.body).to.deep.equal({ message: 'Caretaker belongs to another organization' });
+  });
+
+  it('does not link a freelance caretaker to the org when create fails later', async () => {
+    const fixture = await buildFixture();
+    const roles = await Role.find({}).lean();
+    const roleIds = roles.reduce((acc, role) => {
+      acc[role.name] = role._id;
+      return acc;
+    }, {});
+    const freelanceCaretaker = await createUser({
+      fullname: 'Freelance Caretaker',
+      email: 'freelance-caretaker@test.local',
+      role: roleIds.caretaker,
+    });
+
+    const req = {
+      query: { orgId: String(fixture.organization._id) },
+      body: {
+        fullname: 'Failed Patient',
+        gender: 'male',
+        dateOfBirth: '1985-01-01',
+        caretakerId: String(freelanceCaretaker._id),
+        doctorId: String(fixture.newCaretaker._id),
+      },
+      user: { _id: String(fixture.admin._id) },
+    };
+    const res = makeRes();
+
+    await adminPatientController.createPatient(req, res);
+
+    expect(res.statusCode).to.equal(400);
+    expect(res.body).to.deep.equal({ message: 'doctorId must be a doctor' });
+
+    const reloadedCaretaker = await User.findById(freelanceCaretaker._id).lean();
+    const failedPatient = await Patient.findOne({ fullname: 'Failed Patient' }).lean();
+
+    expect(reloadedCaretaker.organization || null).to.equal(null);
+    expect(failedPatient).to.equal(null);
+  });
+
+  it('blocks explicit org access when the admin does not belong to that org', async () => {
+    const fixture = await buildFixture();
+    const roleIds = await Role.find({}).lean().then((roles) => roles.reduce((acc, role) => {
+      acc[role.name] = role._id;
+      return acc;
+    }, {}));
+    const otherOrg = await buildSecondOrg(roleIds);
+
+    const req = {
+      params: { id: String(fixture.patient._id) },
+      query: { orgId: String(otherOrg.otherOrganization._id) },
+      body: {
+        nurseId: String(fixture.newNurse._id),
+      },
+      user: { _id: String(fixture.admin._id) },
+    };
+    const res = makeRes();
+
+    await adminPatientController.reassign(req, res);
+
+    expect(res.statusCode).to.equal(404);
+    expect(res.body).to.deep.equal({ message: 'Organization not found for admin' });
+  });
+});

--- a/src/test/adminPatientReassign.cjs
+++ b/src/test/adminPatientReassign.cjs
@@ -222,7 +222,7 @@ describe('admin patient reassign flow', function () {
     await mongoose.disconnect();
   });
 
-  it('reassigns caretaker, nurse, and doctor in the same org and removes old reverse assignments', async () => {
+  it('reassigns caretaker and doctor while appending a new nurse in the same org', async () => {
     const fixture = await buildFixture();
     const req = {
       params: { id: String(fixture.patient._id) },
@@ -242,13 +242,19 @@ describe('admin patient reassign flow', function () {
     expect(res.body.message).to.equal('Assignments updated');
     expect(String(res.body.patient.caretaker._id)).to.equal(String(fixture.newCaretaker._id));
     expect(String(res.body.patient.assignedDoctor._id)).to.equal(String(fixture.newDoctor._id));
-    expect(res.body.patient.assignedNurses).to.have.length(1);
-    expect(String(res.body.patient.assignedNurses[0]._id)).to.equal(String(fixture.newNurse._id));
+    expect(res.body.patient.assignedNurses).to.have.length(2);
+    expect(res.body.patient.assignedNurses.map((nurse) => String(nurse._id))).to.have.members([
+      String(fixture.oldNurse._id),
+      String(fixture.newNurse._id),
+    ]);
 
     const updatedPatient = await Patient.findById(fixture.patient._id).lean();
     expect(String(updatedPatient.caretaker)).to.equal(String(fixture.newCaretaker._id));
     expect(String(updatedPatient.assignedDoctor)).to.equal(String(fixture.newDoctor._id));
-    expect(updatedPatient.assignedNurses.map(String)).to.deep.equal([String(fixture.newNurse._id)]);
+    expect(updatedPatient.assignedNurses.map(String)).to.have.members([
+      String(fixture.oldNurse._id),
+      String(fixture.newNurse._id),
+    ]);
 
     const [
       oldCaretaker,
@@ -267,10 +273,10 @@ describe('admin patient reassign flow', function () {
     ]);
 
     expect((oldCaretaker.assignedPatients || []).map(String)).to.not.include(String(fixture.patient._id));
-    expect((oldNurse.assignedPatients || []).map(String)).to.not.include(String(fixture.patient._id));
     expect((oldDoctor.assignedPatients || []).map(String)).to.not.include(String(fixture.patient._id));
 
     expect((newCaretaker.assignedPatients || []).map(String)).to.include(String(fixture.patient._id));
+    expect((oldNurse.assignedPatients || []).map(String)).to.include(String(fixture.patient._id));
     expect((newNurse.assignedPatients || []).map(String)).to.include(String(fixture.patient._id));
     expect((newDoctor.assignedPatients || []).map(String)).to.include(String(fixture.patient._id));
   });
@@ -295,8 +301,11 @@ describe('admin patient reassign flow', function () {
     expect(res.body.message).to.equal('Assignments updated');
     expect(String(res.body.patient.caretaker._id)).to.equal(String(fixture.oldCaretaker._id));
     expect(String(res.body.patient.assignedDoctor._id)).to.equal(String(fixture.newDoctor._id));
-    expect(res.body.patient.assignedNurses).to.have.length(1);
-    expect(String(res.body.patient.assignedNurses[0]._id)).to.equal(String(fixture.newNurse._id));
+    expect(res.body.patient.assignedNurses).to.have.length(2);
+    expect(res.body.patient.assignedNurses.map((nurse) => String(nurse._id))).to.have.members([
+      String(fixture.oldNurse._id),
+      String(fixture.newNurse._id),
+    ]);
 
     const [oldNurse, newNurse, oldDoctor, newDoctor] = await Promise.all([
       User.findById(fixture.oldNurse._id).lean(),
@@ -305,7 +314,7 @@ describe('admin patient reassign flow', function () {
       User.findById(fixture.newDoctor._id).lean(),
     ]);
 
-    expect((oldNurse.assignedPatients || []).map(String)).to.not.include(String(fixture.patient._id));
+    expect((oldNurse.assignedPatients || []).map(String)).to.include(String(fixture.patient._id));
     expect((oldDoctor.assignedPatients || []).map(String)).to.not.include(String(fixture.patient._id));
     expect((newNurse.assignedPatients || []).map(String)).to.include(String(fixture.patient._id));
     expect((newDoctor.assignedPatients || []).map(String)).to.include(String(fixture.patient._id));


### PR DESCRIPTION
This reverts commit 27d4e760ee760c2a58a3c4770442730c0af8ea49.

This PR fixes the admin patient reassignment flow so updating a patient’s caretaker, nurse, or doctor cleanly replaces the previous assignment and keeps reverse user-to-patient links in sync. It also adds stricter organization checks to prevent cross-organization patient creation or reassignment, and updates the admin endpoint to use /patients/:id/reassign. A regression test suite was added to cover the main reassignment and validation scenarios, and Docker Compose now loads environment variables from .env for easier local setup.

Todos
[✅] Tested and working locally
[✅] Code follows the style guidelines of this project
[✅] I have performed a self-review of my code
[✅] Code changes documented
[✅] Requested review from >= 1 devs on the team
How to test
Start the app and MongoDB locally with docker compose up --build.
As an admin, create or use a patient in your organization with an assigned caretaker, nurse, and doctor.
Call PUT /api/v1/admin/patients/:id/reassign?orgId=<orgId> with replacement caretakerId, nurseId, and/or doctorId.
Confirm the patient now shows the new assignments and the previous users no longer retain that patient in their assigned list.
Verify invalid role input returns 400, cross-org reassignment is blocked, and unauthorized orgId access returns 404.
Associated MS Planner Tasks
Member 4 — Patient Assignment and Reassignment