### PR TITLE
Add doctor profile retrieval and update endpoints

### DIFF
--- a/src/config/db.js
+++ b/src/config/db.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const mongoose = require('mongoose');
 const seedRoles = require('../seedRoles');
 const seedData = require('../seedData');
+const seedDoctorData = require('../seedDoctorData');
 
 const mongoDBUrl = process.env.MONGODB_URI;
 
@@ -20,6 +21,7 @@ const connectDB = async () => {
 
     // Seed data when the server starts
     await seedData();
+    await seedDoctorData();
     console.log("Data seeded successfully");
   } catch (err) {
     console.error("MongoDB connection error:", err.message);

--- a/src/config/db.js
+++ b/src/config/db.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const seedRoles = require('../seedRoles');
 const seedData = require('../seedData');
 const seedDoctorData = require('../seedDoctorData');
+const seedStaffData = require('../seedStaffData');
 
 const mongoDBUrl = process.env.MONGODB_URI;
 
@@ -21,6 +22,7 @@ const connectDB = async () => {
 
     // Seed data when the server starts
     await seedData();
+    await seedStaffData();
     await seedDoctorData();
     console.log("Data seeded successfully");
   } catch (err) {

--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -511,12 +511,18 @@ exports.deleteTask = async (req, res) => {
  * /api/v1/admin/dashboard-summary:
  *   get:
  *     summary: Get admin dashboard summary
+ *     description: >-
+ *       Returns a system-wide snapshot for administrators. Includes total and active
+ *       patient counts, a staff breakdown by role with pending approval count, a full
+ *       task breakdown (total, completed, in-progress, pending, and overdue) across
+ *       all staff, task completion rate, and a count of patient logs created
+ *       system-wide in the last 7 days. Requires a valid JWT with the **admin** role.
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
  *     responses:
  *       200:
- *         description: Admin dashboard summary
+ *         description: Admin dashboard summary fetched successfully.
  *         content:
  *           application/json:
  *             schema:
@@ -524,45 +530,75 @@ exports.deleteTask = async (req, res) => {
  *               properties:
  *                 totalPatients:
  *                   type: integer
- *                   description: Total patients in the system
+ *                   description: Total patients registered in the system (including deleted).
+ *                   example: 20
  *                 totalActivePatients:
  *                   type: integer
- *                   description: Active (non-deleted) patients
+ *                   description: Active (non-deleted) patients in the system.
+ *                   example: 18
  *                 staff:
  *                   type: object
+ *                   description: Breakdown of registered staff accounts.
  *                   properties:
  *                     total:
  *                       type: integer
- *                       description: Total staff (doctors, nurses, caretakers)
+ *                       description: Total staff across all clinical roles (doctors, nurses, caretakers).
+ *                       example: 12
  *                     doctors:
  *                       type: integer
+ *                       description: Number of users with the doctor role.
+ *                       example: 3
  *                     nurses:
  *                       type: integer
+ *                       description: Number of users with the nurse role.
+ *                       example: 5
  *                     caretakers:
  *                       type: integer
+ *                       description: Number of users with the caretaker role.
+ *                       example: 4
  *                     pendingApprovals:
  *                       type: integer
- *                       description: Staff accounts awaiting approval
+ *                       description: Staff accounts with approvalStatus = "pending".
+ *                       example: 2
  *                 totalTasks:
  *                   type: integer
+ *                   description: Total tasks across all staff and patients in the system.
+ *                   example: 45
  *                 completedTasks:
  *                   type: integer
+ *                   description: Tasks marked as completed system-wide.
+ *                   example: 20
  *                 inProgressTasks:
  *                   type: integer
+ *                   description: Tasks currently marked as in progress system-wide.
+ *                   example: 8
  *                 pendingTasks:
  *                   type: integer
- *                   description: Tasks not yet started
+ *                   description: Tasks not yet started (totalTasks − completed − inProgress).
+ *                   example: 17
  *                 overdueTasks:
  *                   type: integer
- *                   description: Incomplete tasks whose due date has passed
+ *                   description: Incomplete tasks whose due date has already passed, system-wide.
+ *                   example: 6
  *                 taskCompletionRate:
  *                   type: integer
- *                   description: Percentage of completed tasks
+ *                   description: Percentage of tasks completed system-wide (0–100).
+ *                   example: 44
  *                 recentLogsCount:
  *                   type: integer
- *                   description: Patient logs created system-wide in the last 7 days
+ *                   description: Patient log entries created system-wide in the last 7 days.
+ *                   example: 14
  *       500:
- *         description: Error fetching dashboard summary
+ *         description: Unexpected server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                 details:
+ *                   type: string
  */
 exports.getDashboardSummary = async (req, res) => {
   try {

--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -4,6 +4,7 @@ const Task = require('../models/Task');
 const CarePlan = require('../models/CarePlan');
 const User = require('../models/User');
 const Role = require('../models/Role');
+const PatientLog = require('../models/PatientLog');
 //const SupportTicket = require('../models/SupportTicket');
 const notifyRules = require('../services/notifyRules');
 
@@ -523,42 +524,99 @@ exports.deleteTask = async (req, res) => {
  *               properties:
  *                 totalPatients:
  *                   type: integer
+ *                   description: Total patients in the system
  *                 totalActivePatients:
  *                   type: integer
- *                 totalStaff:
- *                   type: integer
+ *                   description: Active (non-deleted) patients
+ *                 staff:
+ *                   type: object
+ *                   properties:
+ *                     total:
+ *                       type: integer
+ *                       description: Total staff (doctors, nurses, caretakers)
+ *                     doctors:
+ *                       type: integer
+ *                     nurses:
+ *                       type: integer
+ *                     caretakers:
+ *                       type: integer
+ *                     pendingApprovals:
+ *                       type: integer
+ *                       description: Staff accounts awaiting approval
  *                 totalTasks:
  *                   type: integer
  *                 completedTasks:
  *                   type: integer
+ *                 inProgressTasks:
+ *                   type: integer
  *                 pendingTasks:
  *                   type: integer
+ *                   description: Tasks not yet started
+ *                 overdueTasks:
+ *                   type: integer
+ *                   description: Incomplete tasks whose due date has passed
  *                 taskCompletionRate:
  *                   type: integer
  *                   description: Percentage of completed tasks
+ *                 recentLogsCount:
+ *                   type: integer
+ *                   description: Patient logs created system-wide in the last 7 days
  *       500:
  *         description: Error fetching dashboard summary
  */
 exports.getDashboardSummary = async (req, res) => {
   try {
-    const totalPatients = await Patient.countDocuments();
-    const totalActivePatients = await Patient.countDocuments({ isDeleted: false });
-    const totalTasks = await Task.countDocuments();
-    const totalStaff = await User.countDocuments({ role: { $in: await Role.find({ name: { $in: ['nurse', 'caretaker', 'doctor'] } }).distinct('_id') } });
-    const completedTasks = await Task.countDocuments({ status: 'completed' });
-    const pendingTasks = await Task.countDocuments({ status: 'pending' });
+    const now = new Date();
+    const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000);
 
-    const summary = {
+    const staffRoleIds = await Role.find({ name: { $in: ['nurse', 'caretaker', 'doctor'] } }).distinct('_id');
+
+    const [
       totalPatients,
       totalActivePatients,
       totalStaff,
+      totalDoctors,
+      totalNurses,
+      totalCaretakers,
+      pendingApprovals,
       totalTasks,
       completedTasks,
-      pendingTasks,
-      taskCompletionRate: totalTasks ? Math.round((completedTasks / totalTasks) * 100) : 0,
-    };
+      inProgressTasks,
+      overdueTasks,
+      recentLogsCount,
+    ] = await Promise.all([
+      Patient.countDocuments(),
+      Patient.countDocuments({ isDeleted: false }),
+      User.countDocuments({ role: { $in: staffRoleIds } }),
+      User.countDocuments({ role: (await Role.findOne({ name: 'doctor' }).select('_id').lean())?._id }),
+      User.countDocuments({ role: (await Role.findOne({ name: 'nurse' }).select('_id').lean())?._id }),
+      User.countDocuments({ role: (await Role.findOne({ name: 'caretaker' }).select('_id').lean())?._id }),
+      User.countDocuments({ approvalStatus: 'pending' }),
+      Task.countDocuments(),
+      Task.countDocuments({ status: 'completed' }),
+      Task.countDocuments({ status: 'in progress' }),
+      Task.countDocuments({ status: { $ne: 'completed' }, dueDate: { $lt: now } }),
+      PatientLog.countDocuments({ createdAt: { $gte: sevenDaysAgo } }),
+    ]);
 
-    res.status(200).json(summary);
+    res.status(200).json({
+      totalPatients,
+      totalActivePatients,
+      staff: {
+        total: totalStaff,
+        doctors: totalDoctors,
+        nurses: totalNurses,
+        caretakers: totalCaretakers,
+        pendingApprovals,
+      },
+      totalTasks,
+      completedTasks,
+      inProgressTasks,
+      pendingTasks: totalTasks - completedTasks - inProgressTasks,
+      overdueTasks,
+      taskCompletionRate: totalTasks ? Math.round((completedTasks / totalTasks) * 100) : 0,
+      recentLogsCount,
+    });
   } catch (error) {
     res.status(500).json({ message: 'Error fetching dashboard summary', details: error.message });
   }

--- a/src/controllers/caretakerController.js
+++ b/src/controllers/caretakerController.js
@@ -409,9 +409,18 @@ exports.getReportsByPatient = async (req, res) => {
  *                 completedTasks:
  *                   type: integer
  *                   description: Completed tasks for this caretaker
+ *                 inProgressTasks:
+ *                   type: integer
+ *                   description: Tasks currently in progress for this caretaker
  *                 pendingTasks:
  *                   type: integer
- *                   description: Pending tasks for this caretaker
+ *                   description: Tasks not yet started for this caretaker
+ *                 overdueTasks:
+ *                   type: integer
+ *                   description: Incomplete tasks whose due date has passed
+ *                 taskCompletionRate:
+ *                   type: integer
+ *                   description: Percentage of completed tasks
  *                 recentLogsCount:
  *                   type: integer
  *                   description: Logs created by this caretaker in the last 7 days
@@ -422,41 +431,38 @@ exports.getReportsByPatient = async (req, res) => {
 exports.getDashboardSummary = async (req, res) => {
   try {
     const caretakerId = req.user._id;
+    const now = new Date();
+    const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000);
 
-    // Get Role _id for "caretaker"
-    const caretakerRole = await Role.findOne({ name: 'caretaker' }).lean();
-    if (!caretakerRole) {
-      return res.status(500).json({ error: 'Role "caretaker" not found' });
-    }
-
-    // Total patients assigned to this caretaker
-    const totalPatients = await Patient.countDocuments({ caretaker: caretakerId });
-
-    // Total active patients (not discharged or deceased)
-    const totalActivePatients = await Patient.countDocuments({ caretaker: caretakerId, isDeleted: false });
-
-    // Total pending tasks assigned to this caretaker
-    const totalTasks = await Task.countDocuments({ caretaker: caretakerId });
-    const completedTasks = await Task.countDocuments({ caretaker: caretakerId, status: 'completed' });
-    const pendingTasks = totalTasks - completedTasks;
-
-    // Total Patient Logs for this caretaker
-    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    const recentLogsCount = await PatientLog.countDocuments({
-      createdBy: req.user._id,
-      createdAt: { $gte: sevenDaysAgo }
-    });
-
-    const summary = {
+    const [
       totalPatients,
       totalActivePatients,
       totalTasks,
       completedTasks,
-      pendingTasks,
-      recentLogsCount
-    };
+      inProgressTasks,
+      overdueTasks,
+      recentLogsCount,
+    ] = await Promise.all([
+      Patient.countDocuments({ caretaker: caretakerId }),
+      Patient.countDocuments({ caretaker: caretakerId, isDeleted: false }),
+      Task.countDocuments({ caretaker: caretakerId }),
+      Task.countDocuments({ caretaker: caretakerId, status: 'completed' }),
+      Task.countDocuments({ caretaker: caretakerId, status: 'in progress' }),
+      Task.countDocuments({ caretaker: caretakerId, status: { $ne: 'completed' }, dueDate: { $lt: now } }),
+      PatientLog.countDocuments({ createdBy: caretakerId, createdAt: { $gte: sevenDaysAgo } }),
+    ]);
 
-    res.status(200).json(summary);
+    res.status(200).json({
+      totalPatients,
+      totalActivePatients,
+      totalTasks,
+      completedTasks,
+      inProgressTasks,
+      pendingTasks: totalTasks - completedTasks - inProgressTasks,
+      overdueTasks,
+      taskCompletionRate: totalTasks ? Math.round((completedTasks / totalTasks) * 100) : 0,
+      recentLogsCount,
+    });
   } catch (error) {
     res.status(500).json({ error: 'Error fetching dashboard summary', details: error.message });
   }

--- a/src/controllers/caretakerController.js
+++ b/src/controllers/caretakerController.js
@@ -380,18 +380,24 @@ exports.getReportsByPatient = async (req, res) => {
     res.status(500).json({ error: 'Error fetching reports', details: error.message });
   }
 }
-// Caretaker dashboard summary 
+// Caretaker dashboard summary
 /**
  * @swagger
  * /api/v1/caretaker/dashboard-summary:
  *   get:
  *     summary: Get caretaker dashboard summary
+ *     description: >-
+ *       Returns a real-time snapshot of activity scoped to the authenticated caretaker.
+ *       Includes patient counts, a full task breakdown (total, completed, in-progress,
+ *       pending, and overdue), task completion rate, and a count of patient logs
+ *       created by this caretaker in the last 7 days. Requires a valid JWT with the
+ *       **caretaker** role.
  *     tags: [Caretaker]
  *     security:
  *       - bearerAuth: []
  *     responses:
  *       200:
- *         description: Caretaker dashboard summary
+ *         description: Caretaker dashboard summary fetched successfully.
  *         content:
  *           application/json:
  *             schema:
@@ -399,33 +405,51 @@ exports.getReportsByPatient = async (req, res) => {
  *               properties:
  *                 totalPatients:
  *                   type: integer
- *                   description: Total patients under this caretaker
+ *                   description: Total patients under this caretaker (including deleted).
+ *                   example: 3
  *                 totalActivePatients:
  *                   type: integer
- *                   description: Active (non-deleted) patients under this caretaker
+ *                   description: Active (non-deleted) patients under this caretaker.
+ *                   example: 3
  *                 totalTasks:
  *                   type: integer
- *                   description: Total tasks assigned to this caretaker
+ *                   description: Total tasks assigned to this caretaker across all patients.
+ *                   example: 11
  *                 completedTasks:
  *                   type: integer
- *                   description: Completed tasks for this caretaker
+ *                   description: Tasks this caretaker has marked as completed.
+ *                   example: 3
  *                 inProgressTasks:
  *                   type: integer
- *                   description: Tasks currently in progress for this caretaker
+ *                   description: Tasks currently marked as in progress.
+ *                   example: 2
  *                 pendingTasks:
  *                   type: integer
- *                   description: Tasks not yet started for this caretaker
+ *                   description: Tasks not yet started (totalTasks − completed − inProgress).
+ *                   example: 6
  *                 overdueTasks:
  *                   type: integer
- *                   description: Incomplete tasks whose due date has passed
+ *                   description: Incomplete tasks whose due date has already passed.
+ *                   example: 4
  *                 taskCompletionRate:
  *                   type: integer
- *                   description: Percentage of completed tasks
+ *                   description: Percentage of tasks completed (0–100).
+ *                   example: 27
  *                 recentLogsCount:
  *                   type: integer
- *                   description: Logs created by this caretaker in the last 7 days
+ *                   description: Patient log entries created by this caretaker in the last 7 days.
+ *                   example: 2
  *       500:
- *         description: Error fetching caretaker dashboard summary
+ *         description: Unexpected server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 details:
+ *                   type: string
  */
 
 exports.getDashboardSummary = async (req, res) => {

--- a/src/controllers/doctorController.js
+++ b/src/controllers/doctorController.js
@@ -3,6 +3,9 @@ const User = require('../models/User');
 const Role = require('../models/Role');
 const Patient = require('../models/Patient');
 const Doctor = require('../models/Doctor');
+const Prescription = require('../models/Prescription');
+const PatientLog = require('../models/PatientLog');
+const Task = require('../models/Task');
 
 const asInt = (v, d) => {
   const n = parseInt(v, 10);
@@ -143,7 +146,7 @@ exports.assignDoctorToPatient = async (req, res) => {
     const patient = await Patient.findById(patientId);
     if (!patient) return res.status(404).json({ error: 'Patient not found' });
 
-    const prevDoctorId = patient.doctor ? patient.doctor.toString() : null;
+    const prevDoctorId = patient.assignedDoctor ? patient.assignedDoctor.toString() : null;
 
     let newDoctorId = null;
     if (doctorId !== null && doctorId !== undefined && doctorId !== '') {
@@ -161,7 +164,7 @@ exports.assignDoctorToPatient = async (req, res) => {
     }
 
     // Update patient
-    patient.doctor = newDoctorId || null;
+    patient.assignedDoctor = newDoctorId || null;
     await patient.save();
 
     // OPTIONAL: keep User.assignedPatients mirrored on doctor User
@@ -181,7 +184,7 @@ exports.assignDoctorToPatient = async (req, res) => {
     res.status(200).json({
       message: newDoctorId ? 'Doctor assigned' : 'Doctor unassigned',
       patientId: patient._id,
-      doctorId: patient.doctor
+      doctorId: patient.assignedDoctor
     });
   } catch (err) {
     res.status(500).json({ error: 'Error assigning doctor', details: err.message });
@@ -192,29 +195,16 @@ exports.assignDoctorToPatient = async (req, res) => {
  * @swagger
  * /api/v1/doctors/profile:
  *   get:
- *     summary: Get a doctor's profile
+ *     summary: Get the logged-in doctor's profile
  *     description: >-
- *       Returns the full profile for a doctor, combining their User account details
- *       (name, email, role, organisation, assigned patients) with their Doctor-specific
- *       record (phone, gender, age, address). The Doctor-specific record is stored in a
- *       separate collection linked by the user ID. Requires a valid JWT issued to a user
- *       with the **doctor** role. Provide either `doctorId` or `email` as a query parameter.
+ *       Returns the full profile for the currently authenticated doctor, combining their
+ *       User account details (name, email, role, organisation, assigned patients) with their
+ *       Doctor-specific record (phone, gender, age, address) stored in a separate collection.
+ *       The doctor is identified from the JWT — no query parameters are required.
+ *       Requires a valid JWT issued to a user with the **doctor** role.
  *     tags: [Doctor]
  *     security:
  *       - bearerAuth: []
- *     parameters:
- *       - in: query
- *         name: doctorId
- *         schema:
- *           type: string
- *           example: "6641a2f3c89e4b001f3d9abc"
- *         description: MongoDB ObjectId of the doctor's User record. Takes priority over `email` if both are supplied.
- *       - in: query
- *         name: email
- *         schema:
- *           type: string
- *           example: "johndoctor@example.com"
- *         description: Email address of the doctor. Used only when `doctorId` is omitted.
  *     responses:
  *       200:
  *         description: Doctor profile fetched successfully.
@@ -228,7 +218,7 @@ exports.assignDoctorToPatient = async (req, res) => {
  *                   example: "6641a2f3c89e4b001f3d9abc"
  *                 fullname:
  *                   type: string
- *                   example: "John Doe"
+ *                   example: "Dr. Seed"
  *                 email:
  *                   type: string
  *                   example: "johndoctor@example.com"
@@ -263,7 +253,7 @@ exports.assignDoctorToPatient = async (req, res) => {
  *                         type: string
  *                 profile:
  *                   type: object
- *                   description: Doctor-specific profile data stored in the Doctor collection.
+ *                   description: Doctor-specific data stored in the Doctor collection. Empty object if not yet set.
  *                   properties:
  *                     phone:
  *                       type: string
@@ -281,18 +271,8 @@ exports.assignDoctorToPatient = async (req, res) => {
  *                       type: string
  *                       nullable: true
  *                       example: "123 Health St, Sydney NSW 2000"
- *       400:
- *         description: Neither `doctorId` nor `email` was provided.
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 error:
- *                   type: string
- *                   example: "Please provide either doctorId or email"
  *       404:
- *         description: No user matching the given `doctorId` or `email` was found.
+ *         description: The authenticated user's doctor record was not found.
  *         content:
  *           application/json:
  *             schema:
@@ -315,14 +295,9 @@ exports.assignDoctorToPatient = async (req, res) => {
  */
 exports.getProfile = async (req, res) => {
   try {
-    const { doctorId, email } = req.query;
+    const doctorId = req.user._id;
 
-    const query = doctorId ? { _id: doctorId } : email ? { email } : null;
-    if (!query) {
-      return res.status(400).json({ error: 'Please provide either doctorId or email' });
-    }
-
-    const user = await User.findOne(query)
+    const user = await User.findById(doctorId)
       .select('-password_hash -__v')
       .populate('role', 'name')
       .populate('organization', 'name')
@@ -333,7 +308,7 @@ exports.getProfile = async (req, res) => {
       return res.status(404).json({ error: 'Doctor not found' });
     }
 
-    const profile = await Doctor.findOne({ user: user._id }).select('-__v -user').lean();
+    const profile = await Doctor.findOne({ user: doctorId }).select('-__v -user').lean();
 
     res.status(200).json({ ...user, profile: profile || {} });
   } catch (error) {
@@ -345,15 +320,15 @@ exports.getProfile = async (req, res) => {
  * @swagger
  * /api/v1/doctors/profile:
  *   put:
- *     summary: Update a doctor's profile
+ *     summary: Update the logged-in doctor's profile
  *     description: >-
- *       Updates profile information for a doctor. Fields are written to two collections:
- *       `fullname` and `email` are updated on the **User** record; `phone`, `gender`,
- *       `age`, and `address` are upserted into the **Doctor** collection linked by the
- *       user ID. The Doctor record is created automatically on the first update — no
- *       separate registration step is required. Only fields included in the request body
- *       are changed; omitted fields are left as-is. Requires a valid JWT issued to a user
- *       with the **doctor** role.
+ *       Updates profile information for the currently authenticated doctor. The doctor is
+ *       identified from the JWT — no `doctorId` is required in the body. Fields are written
+ *       to two collections: `fullname` and `email` are updated on the **User** record;
+ *       `phone`, `gender`, `age`, and `address` are upserted into the **Doctor** collection.
+ *       The Doctor record is created automatically on the first update. Only fields included
+ *       in the request body are changed; omitted fields are left as-is. Requires a valid JWT
+ *       issued to a user with the **doctor** role.
  *     tags: [Doctor]
  *     security:
  *       - bearerAuth: []
@@ -363,17 +338,11 @@ exports.getProfile = async (req, res) => {
  *         application/json:
  *           schema:
  *             type: object
- *             required:
- *               - doctorId
  *             properties:
- *               doctorId:
- *                 type: string
- *                 description: MongoDB ObjectId of the doctor's User record.
- *                 example: "6641a2f3c89e4b001f3d9abc"
  *               fullname:
  *                 type: string
  *                 description: Updated display name. Written to the User record.
- *                 example: "John Doe"
+ *                 example: "Dr. Seed"
  *               email:
  *                 type: string
  *                 description: Updated email address. Written to the User record. Must be unique.
@@ -398,8 +367,7 @@ exports.getProfile = async (req, res) => {
  *             full update:
  *               summary: Update all fields
  *               value:
- *                 doctorId: "6641a2f3c89e4b001f3d9abc"
- *                 fullname: "John Doe"
+ *                 fullname: "Dr. Seed"
  *                 email: "johndoctor@example.com"
  *                 phone: "04082234"
  *                 gender: "M"
@@ -408,7 +376,6 @@ exports.getProfile = async (req, res) => {
  *             partial update:
  *               summary: Update phone and address only
  *               value:
- *                 doctorId: "6641a2f3c89e4b001f3d9abc"
  *                 phone: "0411999888"
  *                 address: "456 Care Ave, Melbourne VIC 3000"
  *     responses:
@@ -448,18 +415,8 @@ exports.getProfile = async (req, res) => {
  *                     updatedAt:
  *                       type: string
  *                       format: date-time
- *       400:
- *         description: "`doctorId` was not provided in the request body."
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 error:
- *                   type: string
- *                   example: "Missing doctorId"
  *       404:
- *         description: No User record found for the given `doctorId`.
+ *         description: The authenticated user's doctor record was not found.
  *         content:
  *           application/json:
  *             schema:
@@ -482,18 +439,14 @@ exports.getProfile = async (req, res) => {
  */
 exports.updateProfile = async (req, res) => {
   try {
-    const { doctorId, fullname, email, ...doctorFields } = req.body;
+    const doctorId = req.user._id;
+    const { fullname, email, ...doctorFields } = req.body;
 
-    if (!doctorId) {
-      return res.status(400).json({ error: 'Missing doctorId' });
-    }
-
-    const user = await User.findById(doctorId).select('-password_hash -__v').lean();
+    const user = await User.findById(doctorId).select('_id').lean();
     if (!user) {
       return res.status(404).json({ error: 'Doctor not found' });
     }
 
-    // Update allowed User fields
     const userUpdates = {};
     if (fullname) userUpdates.fullname = fullname;
     if (email) userUpdates.email = email;
@@ -502,7 +455,6 @@ exports.updateProfile = async (req, res) => {
       await User.findByIdAndUpdate(doctorId, { $set: userUpdates }, { runValidators: true, context: 'query' });
     }
 
-    // Upsert Doctor-specific fields
     const profile = await Doctor.findOneAndUpdate(
       { user: doctorId },
       { $set: doctorFields },
@@ -515,6 +467,142 @@ exports.updateProfile = async (req, res) => {
     });
   } catch (error) {
     res.status(500).json({ error: 'Error updating profile', details: error.message });
+  }
+};
+
+/**
+ * @swagger
+ * /api/v1/doctors/dashboard-summary:
+ *   get:
+ *     summary: Get the logged-in doctor's dashboard summary
+ *     description: >-
+ *       Returns a real-time snapshot of activity scoped to the authenticated doctor.
+ *       Includes total and active patient counts, a full prescription status breakdown,
+ *       a task breakdown (total, completed, pending, and overdue tasks across all assigned
+ *       patients), and a count of care activity (patient logs) recorded against their
+ *       patients in the last 7 days. Requires a valid JWT issued to a user with the
+ *       **doctor** role.
+ *     tags: [Doctor]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Dashboard summary fetched successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 totalPatients:
+ *                   type: integer
+ *                   description: Total patients assigned to this doctor.
+ *                   example: 12
+ *                 totalActivePatients:
+ *                   type: integer
+ *                   description: Patients assigned to this doctor who have not been deleted.
+ *                   example: 10
+ *                 prescriptions:
+ *                   type: object
+ *                   description: Breakdown of prescriptions written by this doctor.
+ *                   properties:
+ *                     total:
+ *                       type: integer
+ *                       example: 30
+ *                     active:
+ *                       type: integer
+ *                       example: 18
+ *                     completed:
+ *                       type: integer
+ *                       example: 9
+ *                     discontinued:
+ *                       type: integer
+ *                       example: 3
+ *                 tasks:
+ *                   type: object
+ *                   description: Breakdown of tasks across this doctor's assigned patients.
+ *                   properties:
+ *                     total:
+ *                       type: integer
+ *                       example: 25
+ *                     completed:
+ *                       type: integer
+ *                       example: 14
+ *                     pending:
+ *                       type: integer
+ *                       description: Tasks that are not yet completed (includes in-progress).
+ *                       example: 8
+ *                     overdue:
+ *                       type: integer
+ *                       description: Incomplete tasks whose due date has already passed.
+ *                       example: 3
+ *                 recentLogsCount:
+ *                   type: integer
+ *                   description: Patient log entries recorded against this doctor's patients in the last 7 days.
+ *                   example: 5
+ *       500:
+ *         description: Unexpected server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 details:
+ *                   type: string
+ */
+exports.getDashboardSummary = async (req, res) => {
+  try {
+    const doctorId = req.user._id;
+    const now = new Date();
+    const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000);
+
+    // Resolve patient IDs for this doctor — needed for task and log queries
+    const patientIds = await Patient.find({ assignedDoctor: doctorId }).distinct('_id');
+
+    const [
+      totalPatients,
+      totalActivePatients,
+      totalPrescriptions,
+      activePrescriptions,
+      completedPrescriptions,
+      discontinuedPrescriptions,
+      totalTasks,
+      completedTasks,
+      overdueTasks,
+      recentLogsCount,
+    ] = await Promise.all([
+      Patient.countDocuments({ assignedDoctor: doctorId }),
+      Patient.countDocuments({ doctor: doctorId, isDeleted: false }),
+      Prescription.countDocuments({ prescriber: doctorId }),
+      Prescription.countDocuments({ prescriber: doctorId, status: 'active' }),
+      Prescription.countDocuments({ prescriber: doctorId, status: 'completed' }),
+      Prescription.countDocuments({ prescriber: doctorId, status: 'discontinued' }),
+      Task.countDocuments({ patient: { $in: patientIds } }),
+      Task.countDocuments({ patient: { $in: patientIds }, status: 'completed' }),
+      Task.countDocuments({ patient: { $in: patientIds }, status: { $ne: 'completed' }, dueDate: { $lt: now } }),
+      PatientLog.countDocuments({ patient: { $in: patientIds }, createdAt: { $gte: sevenDaysAgo } }),
+    ]);
+
+    res.status(200).json({
+      totalPatients,
+      totalActivePatients,
+      prescriptions: {
+        total: totalPrescriptions,
+        active: activePrescriptions,
+        completed: completedPrescriptions,
+        discontinued: discontinuedPrescriptions,
+      },
+      tasks: {
+        total: totalTasks,
+        completed: completedTasks,
+        pending: totalTasks - completedTasks,
+        overdue: overdueTasks,
+      },
+      recentLogsCount,
+    });
+  } catch (error) {
+    res.status(500).json({ error: 'Error fetching dashboard summary', details: error.message });
   }
 };
 
@@ -604,7 +692,7 @@ exports.listPatientsByDoctor = async (req, res) => {
   
       // Query patients assigned to this doctor
       const [items, total] = await Promise.all([
-        Patient.find({ doctor: doctorId })
+        Patient.find({ assignedDoctor: doctorId })
           .select('_id fullname dateOfBirth gender caretaker assignedNurses doctor created_at updated_at')
           .sort({ fullname: 1 })
           .skip(skip)
@@ -612,7 +700,7 @@ exports.listPatientsByDoctor = async (req, res) => {
           .populate('caretaker', 'fullname email')
           .populate('assignedNurses', 'fullname email')
           .lean(),
-        Patient.countDocuments({ doctor: doctorId })
+        Patient.countDocuments({ assignedDoctor: doctorId })
       ]);
   
       return res.status(200).json({

--- a/src/controllers/doctorController.js
+++ b/src/controllers/doctorController.js
@@ -199,7 +199,7 @@ exports.assignDoctorToPatient = async (req, res) => {
  *     description: >-
  *       Returns the full profile for the currently authenticated doctor, combining their
  *       User account details (name, email, role, organisation, assigned patients) with their
- *       Doctor-specific record (phone, gender, age, address) stored in a separate collection.
+ *       Doctor-specific record (specialization, licenseNumber) stored in a separate collection.
  *       The doctor is identified from the JWT — no query parameters are required.
  *       Requires a valid JWT issued to a user with the **doctor** role.
  *     tags: [Doctor]
@@ -255,22 +255,16 @@ exports.assignDoctorToPatient = async (req, res) => {
  *                   type: object
  *                   description: Doctor-specific data stored in the Doctor collection. Empty object if not yet set.
  *                   properties:
- *                     phone:
+ *                     specialization:
  *                       type: string
  *                       nullable: true
- *                       example: "04082234"
- *                     gender:
+ *                       example: "Geriatrics"
+ *                     licenseNumber:
  *                       type: string
  *                       nullable: true
- *                       example: "M"
- *                     age:
- *                       type: number
- *                       nullable: true
- *                       example: 35
- *                     address:
- *                       type: string
- *                       nullable: true
- *                       example: "123 Health St, Sydney NSW 2000"
+ *                       pattern: '^[A-Z]{2,4}-\d{4}-\d{3,}$'
+ *                       description: "Medical registration number. Format: {TYPE}-{YEAR}-{NUMBER} (e.g. MED-2024-001)"
+ *                       example: "MED-2024-001"
  *       404:
  *         description: The authenticated user's doctor record was not found.
  *         content:
@@ -325,7 +319,7 @@ exports.getProfile = async (req, res) => {
  *       Updates profile information for the currently authenticated doctor. The doctor is
  *       identified from the JWT — no `doctorId` is required in the body. Fields are written
  *       to two collections: `fullname` and `email` are updated on the **User** record;
- *       `phone`, `gender`, `age`, and `address` are upserted into the **Doctor** collection.
+ *       `specialization` and `licenseNumber` are upserted into the **Doctor** collection.
  *       The Doctor record is created automatically on the first update. Only fields included
  *       in the request body are changed; omitted fields are left as-is. Requires a valid JWT
  *       issued to a user with the **doctor** role.
@@ -346,38 +340,29 @@ exports.getProfile = async (req, res) => {
  *               email:
  *                 type: string
  *                 description: Updated email address. Written to the User record. Must be unique.
- *                 example: "johndoctor@example.com"
- *               phone:
+ *                 example: "dr.seed@guardian.com"
+ *               specialization:
  *                 type: string
- *                 description: Contact phone number. Stored in the Doctor record.
- *                 example: "04082234"
- *               gender:
+ *                 description: Medical specialty (e.g. Geriatrics, Cardiology). Stored in the Doctor record.
+ *                 example: "Geriatrics"
+ *               licenseNumber:
  *                 type: string
- *                 description: Gender. Stored in the Doctor record.
- *                 example: "M"
- *               age:
- *                 type: number
- *                 description: Age in years. Stored in the Doctor record.
- *                 example: 35
- *               address:
- *                 type: string
- *                 description: Physical address. Stored in the Doctor record.
- *                 example: "123 Health St, Sydney NSW 2000"
+ *                 pattern: '^[A-Z]{2,4}-\d{4}-\d{3,}$'
+ *                 description: "Medical registration number. Format: {TYPE}-{YEAR}-{NUMBER} (e.g. MED-2024-001). Stored in the Doctor record."
+ *                 example: "MED-2024-001"
  *           examples:
  *             full update:
  *               summary: Update all fields
  *               value:
  *                 fullname: "Dr. Seed"
- *                 email: "johndoctor@example.com"
- *                 phone: "04082234"
- *                 gender: "M"
- *                 age: 35
- *                 address: "123 Health St, Sydney NSW 2000"
+ *                 email: "dr.seed@guardian.com"
+ *                 specialization: "Geriatrics"
+ *                 licenseNumber: "MED-2024-001"
  *             partial update:
- *               summary: Update phone and address only
+ *               summary: Update doctor-specific fields only
  *               value:
- *                 phone: "0411999888"
- *                 address: "456 Care Ave, Melbourne VIC 3000"
+ *                 specialization: "General Practice"
+ *                 licenseNumber: "MED-2024-042"
  *     responses:
  *       200:
  *         description: Doctor profile updated successfully.
@@ -393,22 +378,16 @@ exports.getProfile = async (req, res) => {
  *                   type: object
  *                   description: The updated Doctor record.
  *                   properties:
- *                     phone:
+ *                     specialization:
  *                       type: string
  *                       nullable: true
- *                       example: "04082234"
- *                     gender:
+ *                       example: "Geriatrics"
+ *                     licenseNumber:
  *                       type: string
  *                       nullable: true
- *                       example: "M"
- *                     age:
- *                       type: number
- *                       nullable: true
- *                       example: 35
- *                     address:
- *                       type: string
- *                       nullable: true
- *                       example: "123 Health St, Sydney NSW 2000"
+ *                       pattern: '^[A-Z]{2,4}-\d{4}-\d{3,}$'
+ *                       description: "Medical registration number. Format: {TYPE}-{YEAR}-{NUMBER} (e.g. MED-2024-001)"
+ *                       example: "MED-2024-001"
  *                     createdAt:
  *                       type: string
  *                       format: date-time
@@ -425,6 +404,16 @@ exports.getProfile = async (req, res) => {
  *                 error:
  *                   type: string
  *                   example: "Doctor not found"
+ *       409:
+ *         description: The provided email is already in use by another account.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Email already in use"
  *       500:
  *         description: Unexpected server error.
  *         content:
@@ -440,7 +429,7 @@ exports.getProfile = async (req, res) => {
 exports.updateProfile = async (req, res) => {
   try {
     const doctorId = req.user._id;
-    const { fullname, email, ...doctorFields } = req.body;
+    const { fullname, email, specialization, licenseNumber } = req.body;
 
     const user = await User.findById(doctorId).select('_id').lean();
     if (!user) {
@@ -448,12 +437,24 @@ exports.updateProfile = async (req, res) => {
     }
 
     const userUpdates = {};
-    if (fullname) userUpdates.fullname = fullname;
-    if (email) userUpdates.email = email;
+    if (fullname) userUpdates.fullname = fullname.trim();
+    if (email) {
+      const normalized = email.toLowerCase().trim();
+      const conflict = await User.findOne({ email: normalized, _id: { $ne: doctorId } }).select('_id').lean();
+      if (conflict) {
+        return res.status(409).json({ error: 'Email already in use' });
+      }
+      userUpdates.email = normalized;
+    }
 
     if (Object.keys(userUpdates).length) {
       await User.findByIdAndUpdate(doctorId, { $set: userUpdates }, { runValidators: true, context: 'query' });
     }
+
+    // Whitelist doctor-specific fields — never allow `user` or other schema fields to be overwritten
+    const doctorFields = {};
+    if (specialization !== undefined) doctorFields.specialization = specialization;
+    if (licenseNumber !== undefined) doctorFields.licenseNumber = licenseNumber;
 
     const profile = await Doctor.findOneAndUpdate(
       { user: doctorId },
@@ -527,10 +528,14 @@ exports.updateProfile = async (req, res) => {
  *                     completed:
  *                       type: integer
  *                       example: 14
+ *                     inProgress:
+ *                       type: integer
+ *                       description: Tasks currently marked as in progress.
+ *                       example: 3
  *                     pending:
  *                       type: integer
- *                       description: Tasks that are not yet completed (includes in-progress).
- *                       example: 8
+ *                       description: Tasks not yet started (total − completed − inProgress).
+ *                       example: 5
  *                     overdue:
  *                       type: integer
  *                       description: Incomplete tasks whose due date has already passed.
@@ -569,17 +574,19 @@ exports.getDashboardSummary = async (req, res) => {
       discontinuedPrescriptions,
       totalTasks,
       completedTasks,
+      inProgressTasks,
       overdueTasks,
       recentLogsCount,
     ] = await Promise.all([
       Patient.countDocuments({ assignedDoctor: doctorId }),
-      Patient.countDocuments({ doctor: doctorId, isDeleted: false }),
+      Patient.countDocuments({ assignedDoctor: doctorId, isDeleted: false }),
       Prescription.countDocuments({ prescriber: doctorId }),
       Prescription.countDocuments({ prescriber: doctorId, status: 'active' }),
       Prescription.countDocuments({ prescriber: doctorId, status: 'completed' }),
       Prescription.countDocuments({ prescriber: doctorId, status: 'discontinued' }),
       Task.countDocuments({ patient: { $in: patientIds } }),
       Task.countDocuments({ patient: { $in: patientIds }, status: 'completed' }),
+      Task.countDocuments({ patient: { $in: patientIds }, status: 'in progress' }),
       Task.countDocuments({ patient: { $in: patientIds }, status: { $ne: 'completed' }, dueDate: { $lt: now } }),
       PatientLog.countDocuments({ patient: { $in: patientIds }, createdAt: { $gte: sevenDaysAgo } }),
     ]);
@@ -596,7 +603,8 @@ exports.getDashboardSummary = async (req, res) => {
       tasks: {
         total: totalTasks,
         completed: completedTasks,
-        pending: totalTasks - completedTasks,
+        inProgress: inProgressTasks,
+        pending: totalTasks - completedTasks - inProgressTasks,
         overdue: overdueTasks,
       },
       recentLogsCount,
@@ -611,7 +619,7 @@ exports.getDashboardSummary = async (req, res) => {
  * /api/v1/doctors/{doctorId}/patients:
  *   get:
  *     summary: Get patients assigned to a doctor
- *     description: Returns a paginated list of patients whose `doctor` equals the given doctorId. Allowed for the same doctor, admin, or caretaker.
+ *     description: Returns a paginated list of patients whose `assignedDoctor` equals the given doctorId. Allowed for the same doctor, admin, or caretaker.
  *     tags: [Doctor]
  *     security:
  *       - bearerAuth: []
@@ -693,7 +701,7 @@ exports.listPatientsByDoctor = async (req, res) => {
       // Query patients assigned to this doctor
       const [items, total] = await Promise.all([
         Patient.find({ assignedDoctor: doctorId })
-          .select('_id fullname dateOfBirth gender caretaker assignedNurses doctor created_at updated_at')
+          .select('_id fullname dateOfBirth gender caretaker assignedNurses assignedDoctor created_at updated_at')
           .sort({ fullname: 1 })
           .skip(skip)
           .limit(limit)

--- a/src/controllers/doctorController.js
+++ b/src/controllers/doctorController.js
@@ -262,8 +262,10 @@ exports.assignDoctorToPatient = async (req, res) => {
  *                     licenseNumber:
  *                       type: string
  *                       nullable: true
- *                       pattern: '^[A-Z]{2,4}-\d{4}-\d{3,}$'
- *                       description: "Medical registration number. Format: {TYPE}-{YEAR}-{NUMBER} (e.g. MED-2024-001)"
+ *                       description: >-
+ *                         Medical registration number. Accepted as a free-form string for now.
+ *                         TODO: implement proper format and authority validation
+ *                         (e.g. verify against PRC/PMA registry or enforce a country-specific pattern).
  *                       example: "MED-2024-001"
  *       404:
  *         description: The authenticated user's doctor record was not found.
@@ -347,8 +349,10 @@ exports.getProfile = async (req, res) => {
  *                 example: "Geriatrics"
  *               licenseNumber:
  *                 type: string
- *                 pattern: '^[A-Z]{2,4}-\d{4}-\d{3,}$'
- *                 description: "Medical registration number. Format: {TYPE}-{YEAR}-{NUMBER} (e.g. MED-2024-001). Stored in the Doctor record."
+ *                 description: >-
+ *                   Medical registration number. Accepted as a free-form string for now.
+ *                   TODO: implement proper format and authority validation
+ *                   (e.g. verify against PRC/PMA registry or enforce a country-specific pattern).
  *                 example: "MED-2024-001"
  *           examples:
  *             full update:
@@ -385,8 +389,10 @@ exports.getProfile = async (req, res) => {
  *                     licenseNumber:
  *                       type: string
  *                       nullable: true
- *                       pattern: '^[A-Z]{2,4}-\d{4}-\d{3,}$'
- *                       description: "Medical registration number. Format: {TYPE}-{YEAR}-{NUMBER} (e.g. MED-2024-001)"
+ *                       description: >-
+ *                         Medical registration number. Accepted as a free-form string for now.
+ *                         TODO: implement proper format and authority validation
+ *                         (e.g. verify against PRC/PMA registry or enforce a country-specific pattern).
  *                       example: "MED-2024-001"
  *                     createdAt:
  *                       type: string
@@ -454,6 +460,7 @@ exports.updateProfile = async (req, res) => {
     // Whitelist doctor-specific fields — never allow `user` or other schema fields to be overwritten
     const doctorFields = {};
     if (specialization !== undefined) doctorFields.specialization = specialization;
+    // TODO: validate licenseNumber format and verify against official registry before saving
     if (licenseNumber !== undefined) doctorFields.licenseNumber = licenseNumber;
 
     const profile = await Doctor.findOneAndUpdate(

--- a/src/controllers/doctorController.js
+++ b/src/controllers/doctorController.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 const User = require('../models/User');
 const Role = require('../models/Role');
 const Patient = require('../models/Patient');
+const Doctor = require('../models/Doctor');
 
 const asInt = (v, d) => {
   const n = parseInt(v, 10);
@@ -184,6 +185,336 @@ exports.assignDoctorToPatient = async (req, res) => {
     });
   } catch (err) {
     res.status(500).json({ error: 'Error assigning doctor', details: err.message });
+  }
+};
+
+/**
+ * @swagger
+ * /api/v1/doctors/profile:
+ *   get:
+ *     summary: Get a doctor's profile
+ *     description: >-
+ *       Returns the full profile for a doctor, combining their User account details
+ *       (name, email, role, organisation, assigned patients) with their Doctor-specific
+ *       record (phone, gender, age, address). The Doctor-specific record is stored in a
+ *       separate collection linked by the user ID. Requires a valid JWT issued to a user
+ *       with the **doctor** role. Provide either `doctorId` or `email` as a query parameter.
+ *     tags: [Doctor]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: doctorId
+ *         schema:
+ *           type: string
+ *           example: "6641a2f3c89e4b001f3d9abc"
+ *         description: MongoDB ObjectId of the doctor's User record. Takes priority over `email` if both are supplied.
+ *       - in: query
+ *         name: email
+ *         schema:
+ *           type: string
+ *           example: "johndoctor@example.com"
+ *         description: Email address of the doctor. Used only when `doctorId` is omitted.
+ *     responses:
+ *       200:
+ *         description: Doctor profile fetched successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 _id:
+ *                   type: string
+ *                   example: "6641a2f3c89e4b001f3d9abc"
+ *                 fullname:
+ *                   type: string
+ *                   example: "John Doe"
+ *                 email:
+ *                   type: string
+ *                   example: "johndoctor@example.com"
+ *                 role:
+ *                   type: object
+ *                   properties:
+ *                     _id:
+ *                       type: string
+ *                     name:
+ *                       type: string
+ *                       example: "doctor"
+ *                 organization:
+ *                   type: object
+ *                   nullable: true
+ *                   properties:
+ *                     _id:
+ *                       type: string
+ *                     name:
+ *                       type: string
+ *                 assignedPatients:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       _id:
+ *                         type: string
+ *                       fullname:
+ *                         type: string
+ *                       age:
+ *                         type: number
+ *                       gender:
+ *                         type: string
+ *                 profile:
+ *                   type: object
+ *                   description: Doctor-specific profile data stored in the Doctor collection.
+ *                   properties:
+ *                     phone:
+ *                       type: string
+ *                       nullable: true
+ *                       example: "04082234"
+ *                     gender:
+ *                       type: string
+ *                       nullable: true
+ *                       example: "M"
+ *                     age:
+ *                       type: number
+ *                       nullable: true
+ *                       example: 35
+ *                     address:
+ *                       type: string
+ *                       nullable: true
+ *                       example: "123 Health St, Sydney NSW 2000"
+ *       400:
+ *         description: Neither `doctorId` nor `email` was provided.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Please provide either doctorId or email"
+ *       404:
+ *         description: No user matching the given `doctorId` or `email` was found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Doctor not found"
+ *       500:
+ *         description: Unexpected server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 details:
+ *                   type: string
+ */
+exports.getProfile = async (req, res) => {
+  try {
+    const { doctorId, email } = req.query;
+
+    const query = doctorId ? { _id: doctorId } : email ? { email } : null;
+    if (!query) {
+      return res.status(400).json({ error: 'Please provide either doctorId or email' });
+    }
+
+    const user = await User.findOne(query)
+      .select('-password_hash -__v')
+      .populate('role', 'name')
+      .populate('organization', 'name')
+      .populate('assignedPatients', 'fullname age gender')
+      .lean();
+
+    if (!user) {
+      return res.status(404).json({ error: 'Doctor not found' });
+    }
+
+    const profile = await Doctor.findOne({ user: user._id }).select('-__v -user').lean();
+
+    res.status(200).json({ ...user, profile: profile || {} });
+  } catch (error) {
+    res.status(500).json({ error: 'Error fetching doctor profile', details: error.message });
+  }
+};
+
+/**
+ * @swagger
+ * /api/v1/doctors/profile:
+ *   put:
+ *     summary: Update a doctor's profile
+ *     description: >-
+ *       Updates profile information for a doctor. Fields are written to two collections:
+ *       `fullname` and `email` are updated on the **User** record; `phone`, `gender`,
+ *       `age`, and `address` are upserted into the **Doctor** collection linked by the
+ *       user ID. The Doctor record is created automatically on the first update — no
+ *       separate registration step is required. Only fields included in the request body
+ *       are changed; omitted fields are left as-is. Requires a valid JWT issued to a user
+ *       with the **doctor** role.
+ *     tags: [Doctor]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - doctorId
+ *             properties:
+ *               doctorId:
+ *                 type: string
+ *                 description: MongoDB ObjectId of the doctor's User record.
+ *                 example: "6641a2f3c89e4b001f3d9abc"
+ *               fullname:
+ *                 type: string
+ *                 description: Updated display name. Written to the User record.
+ *                 example: "John Doe"
+ *               email:
+ *                 type: string
+ *                 description: Updated email address. Written to the User record. Must be unique.
+ *                 example: "johndoctor@example.com"
+ *               phone:
+ *                 type: string
+ *                 description: Contact phone number. Stored in the Doctor record.
+ *                 example: "04082234"
+ *               gender:
+ *                 type: string
+ *                 description: Gender. Stored in the Doctor record.
+ *                 example: "M"
+ *               age:
+ *                 type: number
+ *                 description: Age in years. Stored in the Doctor record.
+ *                 example: 35
+ *               address:
+ *                 type: string
+ *                 description: Physical address. Stored in the Doctor record.
+ *                 example: "123 Health St, Sydney NSW 2000"
+ *           examples:
+ *             full update:
+ *               summary: Update all fields
+ *               value:
+ *                 doctorId: "6641a2f3c89e4b001f3d9abc"
+ *                 fullname: "John Doe"
+ *                 email: "johndoctor@example.com"
+ *                 phone: "04082234"
+ *                 gender: "M"
+ *                 age: 35
+ *                 address: "123 Health St, Sydney NSW 2000"
+ *             partial update:
+ *               summary: Update phone and address only
+ *               value:
+ *                 doctorId: "6641a2f3c89e4b001f3d9abc"
+ *                 phone: "0411999888"
+ *                 address: "456 Care Ave, Melbourne VIC 3000"
+ *     responses:
+ *       200:
+ *         description: Doctor profile updated successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "Doctor profile updated successfully"
+ *                 profile:
+ *                   type: object
+ *                   description: The updated Doctor record.
+ *                   properties:
+ *                     phone:
+ *                       type: string
+ *                       nullable: true
+ *                       example: "04082234"
+ *                     gender:
+ *                       type: string
+ *                       nullable: true
+ *                       example: "M"
+ *                     age:
+ *                       type: number
+ *                       nullable: true
+ *                       example: 35
+ *                     address:
+ *                       type: string
+ *                       nullable: true
+ *                       example: "123 Health St, Sydney NSW 2000"
+ *                     createdAt:
+ *                       type: string
+ *                       format: date-time
+ *                     updatedAt:
+ *                       type: string
+ *                       format: date-time
+ *       400:
+ *         description: "`doctorId` was not provided in the request body."
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Missing doctorId"
+ *       404:
+ *         description: No User record found for the given `doctorId`.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Doctor not found"
+ *       500:
+ *         description: Unexpected server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 details:
+ *                   type: string
+ */
+exports.updateProfile = async (req, res) => {
+  try {
+    const { doctorId, fullname, email, ...doctorFields } = req.body;
+
+    if (!doctorId) {
+      return res.status(400).json({ error: 'Missing doctorId' });
+    }
+
+    const user = await User.findById(doctorId).select('-password_hash -__v').lean();
+    if (!user) {
+      return res.status(404).json({ error: 'Doctor not found' });
+    }
+
+    // Update allowed User fields
+    const userUpdates = {};
+    if (fullname) userUpdates.fullname = fullname;
+    if (email) userUpdates.email = email;
+
+    if (Object.keys(userUpdates).length) {
+      await User.findByIdAndUpdate(doctorId, { $set: userUpdates }, { runValidators: true, context: 'query' });
+    }
+
+    // Upsert Doctor-specific fields
+    const profile = await Doctor.findOneAndUpdate(
+      { user: doctorId },
+      { $set: doctorFields },
+      { new: true, upsert: true, runValidators: true, select: '-__v -user' }
+    ).lean();
+
+    res.status(200).json({
+      message: 'Doctor profile updated successfully',
+      profile,
+    });
+  } catch (error) {
+    res.status(500).json({ error: 'Error updating profile', details: error.message });
   }
 };
 

--- a/src/controllers/nurseController.js
+++ b/src/controllers/nurseController.js
@@ -180,9 +180,18 @@ exports.getAssignedPatientsForNurse = async (req, res) => {
  *                 completedTasks:
  *                   type: integer
  *                   description: Completed tasks assigned to the nurse
+ *                 inProgressTasks:
+ *                   type: integer
+ *                   description: Tasks currently in progress
  *                 pendingTasks:
  *                   type: integer
- *                   description: Pending tasks assigned to the nurse
+ *                   description: Tasks not yet started
+ *                 overdueTasks:
+ *                   type: integer
+ *                   description: Incomplete tasks whose due date has passed
+ *                 taskCompletionRate:
+ *                   type: integer
+ *                   description: Percentage of completed tasks
  *                 recentLogsCount:
  *                   type: integer
  *                   description: Patient logs created by the nurse in the last 7 days
@@ -192,41 +201,38 @@ exports.getAssignedPatientsForNurse = async (req, res) => {
 exports.getDashboardSummary = async (req, res) => {
   try {
     const nurseId = req.user._id;
+    const now = new Date();
+    const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000);
 
-    // Get Role _id for "nurse"
-    const nurseRole = await Role.findOne({ name: 'nurse' }).lean();
-    if (!nurseRole) {
-      return res.status(500).json({ error: 'Role "nurse" not found' });
-    }
-
-    // Total patients assigned to this nurse
-    const totalPatients = await Patient.countDocuments({ assignedNurses: nurseId });
-
-    // Total active patients (not discharged or deceased)
-    const totalActivePatients = await Patient.countDocuments({ assignedNurses: nurseId, isDeleted: false });
-
-    // Total pending tasks assigned to this nurse
-    const totalTasks = await Task.countDocuments({ nurse_id: nurseId });
-    const completedTasks = await Task.countDocuments({ nurse_id: nurseId, status: 'completed' });
-    const pendingTasks = totalTasks - completedTasks;
-
-    // Total Patient Logs for this nurse
-    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    const recentLogsCount = await PatientLog.countDocuments({
-      createdBy: req.user._id,
-      createdAt: { $gte: sevenDaysAgo }
-    });
-
-    const summary = {
+    const [
       totalPatients,
       totalActivePatients,
       totalTasks,
       completedTasks,
-      pendingTasks,
-      recentLogsCount
-    };
+      inProgressTasks,
+      overdueTasks,
+      recentLogsCount,
+    ] = await Promise.all([
+      Patient.countDocuments({ assignedNurses: nurseId }),
+      Patient.countDocuments({ assignedNurses: nurseId, isDeleted: false }),
+      Task.countDocuments({ nurse_id: nurseId }),
+      Task.countDocuments({ nurse_id: nurseId, status: 'completed' }),
+      Task.countDocuments({ nurse_id: nurseId, status: 'in progress' }),
+      Task.countDocuments({ nurse_id: nurseId, status: { $ne: 'completed' }, dueDate: { $lt: now } }),
+      PatientLog.countDocuments({ createdBy: nurseId, createdAt: { $gte: sevenDaysAgo } }),
+    ]);
 
-    res.status(200).json(summary);
+    res.status(200).json({
+      totalPatients,
+      totalActivePatients,
+      totalTasks,
+      completedTasks,
+      inProgressTasks,
+      pendingTasks: totalTasks - completedTasks - inProgressTasks,
+      overdueTasks,
+      taskCompletionRate: totalTasks ? Math.round((completedTasks / totalTasks) * 100) : 0,
+      recentLogsCount,
+    });
   } catch (error) {
     res.status(500).json({ error: 'Error fetching dashboard summary', details: error.message });
   }

--- a/src/controllers/nurseController.js
+++ b/src/controllers/nurseController.js
@@ -157,12 +157,18 @@ exports.getAssignedPatientsForNurse = async (req, res) => {
  * /api/v1/nurse/dashboard-summary:
  *   get:
  *     summary: Get nurse dashboard summary
+ *     description: >-
+ *       Returns a real-time snapshot of activity scoped to the authenticated nurse.
+ *       Includes patient counts, a full task breakdown (total, completed, in-progress,
+ *       pending, and overdue), task completion rate, and a count of patient logs
+ *       created by this nurse in the last 7 days. Requires a valid JWT with the
+ *       **nurse** role.
  *     tags: [Nurse]
  *     security:
  *       - bearerAuth: []
  *     responses:
  *       200:
- *         description: Nurse dashboard summary
+ *         description: Nurse dashboard summary fetched successfully.
  *         content:
  *           application/json:
  *             schema:
@@ -170,33 +176,51 @@ exports.getAssignedPatientsForNurse = async (req, res) => {
  *               properties:
  *                 totalPatients:
  *                   type: integer
- *                   description: Total patients assigned to the nurse
+ *                   description: Total patients assigned to this nurse (including deleted).
+ *                   example: 5
  *                 totalActivePatients:
  *                   type: integer
- *                   description: Active (non-deleted) patients assigned to the nurse
+ *                   description: Active (non-deleted) patients assigned to this nurse.
+ *                   example: 4
  *                 totalTasks:
  *                   type: integer
- *                   description: Total tasks assigned to the nurse
+ *                   description: Total tasks assigned to this nurse across all patients.
+ *                   example: 10
  *                 completedTasks:
  *                   type: integer
- *                   description: Completed tasks assigned to the nurse
+ *                   description: Tasks this nurse has marked as completed.
+ *                   example: 4
  *                 inProgressTasks:
  *                   type: integer
- *                   description: Tasks currently in progress
+ *                   description: Tasks currently marked as in progress.
+ *                   example: 2
  *                 pendingTasks:
  *                   type: integer
- *                   description: Tasks not yet started
+ *                   description: Tasks not yet started (totalTasks − completed − inProgress).
+ *                   example: 4
  *                 overdueTasks:
  *                   type: integer
- *                   description: Incomplete tasks whose due date has passed
+ *                   description: Incomplete tasks whose due date has already passed.
+ *                   example: 2
  *                 taskCompletionRate:
  *                   type: integer
- *                   description: Percentage of completed tasks
+ *                   description: Percentage of tasks completed (0–100).
+ *                   example: 40
  *                 recentLogsCount:
  *                   type: integer
- *                   description: Patient logs created by the nurse in the last 7 days
+ *                   description: Patient log entries created by this nurse in the last 7 days.
+ *                   example: 3
  *       500:
- *         description: Error fetching nurse dashboard summary
+ *         description: Unexpected server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 details:
+ *                   type: string
  */
 exports.getDashboardSummary = async (req, res) => {
   try {

--- a/src/models/Doctor.js
+++ b/src/models/Doctor.js
@@ -2,10 +2,8 @@ const mongoose = require('mongoose');
 
 const DoctorSchema = new mongoose.Schema({
   user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true, unique: true },
-  phone: { type: String, default: null },
-  gender: { type: String, default: null },
-  age: { type: Number, default: null },
-  address: { type: String, default: null },
+  specialization: { type: String, default: null },
+  licenseNumber: { type: String, default: null },
 }, {
   timestamps: true
 });

--- a/src/models/Doctor.js
+++ b/src/models/Doctor.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const DoctorSchema = new mongoose.Schema({
   user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true, unique: true },
   specialization: { type: String, default: null },
+  // TODO: add proper format validation and official registry verification for licenseNumber
   licenseNumber: { type: String, default: null },
 }, {
   timestamps: true

--- a/src/models/Doctor.js
+++ b/src/models/Doctor.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const DoctorSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true, unique: true },
+  phone: { type: String, default: null },
+  gender: { type: String, default: null },
+  age: { type: Number, default: null },
+  address: { type: String, default: null },
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('Doctor', DoctorSchema);

--- a/src/routes/doctor.js
+++ b/src/routes/doctor.js
@@ -18,11 +18,10 @@ router.param('doctorId', (req, res, next, id) => {
 // GET /api/v1/doctors -> list all doctors (supports ?search=&page=&limit=)
 router.get('/', verifyToken, doctorController.listDoctors);
 
-// GET /api/v1/doctors/profile -> doctor profile by ?doctorId or ?email
-// PUT /api/v1/doctors/profile -> update doctor profile
-// Must be declared before /:doctorId routes so "profile" is not matched as a doctorId param
+// Static /doctors/* routes must come before /:doctorId to avoid param capture
 router.get('/profile', verifyToken, verifyRole(['doctor']), doctorController.getProfile);
-router.put('/profile', verifyToken, verifyRole(['doctor']), doctorController.updateProfile);;
+router.put('/profile', verifyToken, verifyRole(['doctor']), doctorController.updateProfile);
+router.get('/dashboard-summary', verifyToken, verifyRole(['doctor']), doctorController.getDashboardSummary);;
 
 // GET /api/v1/doctors/:doctorId/patients -> patients assigned to a doctor
 router.get(

--- a/src/routes/doctor.js
+++ b/src/routes/doctor.js
@@ -18,6 +18,12 @@ router.param('doctorId', (req, res, next, id) => {
 // GET /api/v1/doctors -> list all doctors (supports ?search=&page=&limit=)
 router.get('/', verifyToken, doctorController.listDoctors);
 
+// GET /api/v1/doctors/profile -> doctor profile by ?doctorId or ?email
+// PUT /api/v1/doctors/profile -> update doctor profile
+// Must be declared before /:doctorId routes so "profile" is not matched as a doctorId param
+router.get('/profile', verifyToken, verifyRole(['doctor']), doctorController.getProfile);
+router.put('/profile', verifyToken, verifyRole(['doctor']), doctorController.updateProfile);;
+
 // GET /api/v1/doctors/:doctorId/patients -> patients assigned to a doctor
 router.get(
   '/:doctorId/patients',

--- a/src/seedData.js
+++ b/src/seedData.js
@@ -1,10 +1,7 @@
-const bcrypt = require('bcryptjs');
-
-// Models
-const Role = require('./models/Role');
 const User = require('./models/User');
 const Patient = require('./models/Patient');
 const EntryReport = require('./models/EntryReport');
+const Role = require('./models/Role');
 const updateSeedData = require('./updateSeedData');
 
 const getRoleId = async (name) => {
@@ -13,51 +10,63 @@ const getRoleId = async (name) => {
   return role._id;
 };
 
+// Find an existing user by email, or create them.
+// Avoids duplicate-key errors when patients failed to seed but users succeeded.
+const findOrCreateUser = async (email, data) => {
+  const existing = await User.findOne({ email });
+  return existing || User.create(data);
+};
+
 const seedData = async () => {
   try {
-    // Guard on alice specifically so doctor/nurse seeds don't trigger a false skip
-    const alreadySeeded = await User.findOne({ email: 'alice@guardian.com' });
+    // Guard on patients, not alice — if a previous run created users but
+    // crashed before creating patients, we still need to seed the patients.
+    const seedPatientCount = await Patient.countDocuments({
+      fullname: { $in: ['Elderly Patient One', 'Elderly Patient Two'] },
+    });
 
-    if (alreadySeeded) {
-      console.log('⚠️ Existing data detected. Skipping seed to avoid duplication.');
+    if (seedPatientCount >= 2) {
+      console.log('⚠️ Existing seed patients detected. Skipping seed to avoid duplication.');
       await updateSeedData();
       return;
     }
 
-    console.log('🌱 No existing data found. Seeding initial records...');
+    console.log('🌱 Seeding initial records...');
 
-    // Passwords
     const hashedPassword = 'Password123!';
 
-    // Create caretakers
-    const caretaker1 = await User.create({
-      fullname: 'Alice Smith',
-      email: 'alice@guardian.com',
-      password_hash: hashedPassword,
-      role: await getRoleId('caretaker')
-    });
+    const [caretakerRoleId, nurseRoleId] = await Promise.all([
+      getRoleId('caretaker'),
+      getRoleId('nurse'),
+    ]);
 
-    const caretaker2 = await User.create({
-      fullname: 'Bob Johnson',
-      email: 'bob@guardian.com',
-      password_hash: hashedPassword,
-      role: await getRoleId('caretaker')
-    });
-
-    // Create nurses
-    const nurse1 = await User.create({
-      fullname: 'Nurse Jane',
-      email: 'jane@guardian.com',
-      password_hash: hashedPassword,
-      role: await getRoleId('nurse')
-    });
-
-    const nurse2 = await User.create({
-      fullname: 'Nurse Mike',
-      email: 'mike@guardian.com',
-      password_hash: hashedPassword,
-      role: await getRoleId('nurse')
-    });
+    // Create (or find) users
+    const [caretaker1, caretaker2, nurse1, nurse2] = await Promise.all([
+      findOrCreateUser('alice@guardian.com', {
+        fullname: 'Alice Smith',
+        email: 'alice@guardian.com',
+        password_hash: hashedPassword,
+        role: caretakerRoleId,
+      }),
+      findOrCreateUser('bob@guardian.com', {
+        fullname: 'Bob Johnson',
+        email: 'bob@guardian.com',
+        password_hash: hashedPassword,
+        role: caretakerRoleId,
+      }),
+      findOrCreateUser('jane@guardian.com', {
+        fullname: 'Nurse Jane',
+        email: 'jane@guardian.com',
+        password_hash: hashedPassword,
+        role: nurseRoleId,
+      }),
+      findOrCreateUser('mike@guardian.com', {
+        fullname: 'Nurse Mike',
+        email: 'mike@guardian.com',
+        password_hash: hashedPassword,
+        role: nurseRoleId,
+      }),
+    ]);
 
     // Create patients
     const patient1 = await Patient.create({
@@ -75,7 +84,7 @@ const seedData = async () => {
       medicalSummary: 'Managed hypertension with regular blood pressure monitoring. No known surgical history.',
       allergies: ['Penicillin'],
       conditions: ['Hypertension'],
-      notes: 'Prefers morning visits. Responds well to routine.'
+      notes: 'Prefers morning visits. Responds well to routine.',
     });
 
     const patient2 = await Patient.create({
@@ -93,7 +102,7 @@ const seedData = async () => {
       medicalSummary: 'Type 2 Diabetes diagnosed in 2015. Rheumatoid arthritis affecting both hands. On metformin and ibuprofen.',
       allergies: ['Sulfa drugs', 'Shellfish'],
       conditions: ['Type 2 Diabetes', 'Arthritis'],
-      notes: 'Requires low-sugar diet. Arthritis flares in cold weather.'
+      notes: 'Requires low-sugar diet. Arthritis flares in cold weather.',
     });
 
     // Create entry reports
@@ -103,35 +112,36 @@ const seedData = async () => {
         nurse: nurse1._id,
         activityType: 'wake up',
         comment: 'Patient woke up at 6:30 AM and appeared alert.',
-        activityTimestamp: new Date('2024-06-05T06:30:00Z')
+        activityTimestamp: new Date('2024-06-05T06:30:00Z'),
       },
       {
         patient: patient1._id,
         nurse: nurse1._id,
         activityType: 'meal',
         comment: 'Had a light breakfast: toast and tea.',
-        activityTimestamp: new Date('2024-06-05T07:30:00Z')
+        activityTimestamp: new Date('2024-06-05T07:30:00Z'),
       },
       {
         patient: patient2._id,
         nurse: nurse2._id,
         activityType: 'reading',
         comment: 'Read a magazine for 20 minutes.',
-        activityTimestamp: new Date('2024-06-05T10:00:00Z')
+        activityTimestamp: new Date('2024-06-05T10:00:00Z'),
       },
       {
         patient: patient2._id,
         nurse: nurse1._id,
         activityType: 'meditation',
         comment: 'Guided breathing exercise for 15 minutes.',
-        activityTimestamp: new Date('2024-06-05T11:00:00Z')
-      }
+        activityTimestamp: new Date('2024-06-05T11:00:00Z'),
+      },
     ]);
 
     console.log('✅ Seed data inserted successfully');
   } catch (err) {
-    console.error('❌ Error seeding data:', err);
+    console.error('❌ Error seeding data:', err.message || err);
+    throw err;
   }
-}
+};
 
 module.exports = seedData;

--- a/src/seedData.js
+++ b/src/seedData.js
@@ -15,16 +15,10 @@ const getRoleId = async (name) => {
 
 const seedData = async () => {
   try {
-    const userCount = await User.countDocuments();
-    const patientCount = await Patient.countDocuments();
-    const reportCount = await EntryReport.countDocuments();
+    // Guard on alice specifically so doctor/nurse seeds don't trigger a false skip
+    const alreadySeeded = await User.findOne({ email: 'alice@guardian.com' });
 
-    // Clear previous data
-    // await User.deleteMany({});
-    // await Patient.deleteMany({});
-    // await EntryReport.deleteMany({});
-
-    if (userCount > 0 || patientCount > 0 || reportCount > 0) {
+    if (alreadySeeded) {
       console.log('⚠️ Existing data detected. Skipping seed to avoid duplication.');
       await updateSeedData();
       return;

--- a/src/seedDoctorData.js
+++ b/src/seedDoctorData.js
@@ -1,0 +1,288 @@
+'use strict';
+
+const Role = require('./models/Role');
+const User = require('./models/User');
+const Patient = require('./models/Patient');
+const Prescription = require('./models/Prescription');
+const Task = require('./models/Task');
+const PatientLog = require('./models/PatientLog');
+
+const DOCTOR_EMAIL = 'dr.seed@guardian.com';
+
+const getRoleId = async (name) => {
+  const role = await Role.findOne({ name });
+  if (!role) throw new Error(`Role '${name}' not found`);
+  return role._id;
+};
+
+const daysAgo = (n) => new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+const daysFromNow = (n) => new Date(Date.now() + n * 24 * 60 * 60 * 1000);
+
+const seedDoctorData = async () => {
+  try {
+    const [doctorRoleId, caretakerRoleId] = await Promise.all([
+      getRoleId('doctor'),
+      getRoleId('caretaker'),
+    ]);
+
+    // Find or create the seed doctor user
+    let doctor = await User.findOne({ email: DOCTOR_EMAIL });
+    if (!doctor) {
+      doctor = await User.create({
+        fullname: 'Dr. Seed',
+        email: DOCTOR_EMAIL,
+        password_hash: 'Password123!',
+        role: doctorRoleId,
+      });
+      console.log('🌱 Created seed doctor user.');
+    }
+
+    // Guard on patients — if already seeded, skip data creation
+    const existingPatients = await Patient.countDocuments({ assignedDoctor: doctor._id });
+    if (existingPatients > 0) {
+      console.log('Doctor seed data already present — skipping.');
+      return;
+    }
+
+    console.log('Seeding doctor patients, prescriptions, tasks and logs...');
+
+    // Reuse an existing caretaker, or create one (Task.caretaker is required)
+    let caretaker = await User.findOne({ role: caretakerRoleId });
+    if (!caretaker) {
+      caretaker = await User.create({
+        fullname: 'Seed Caretaker',
+        email: 'caretaker.seed@guardian.com',
+        password_hash: 'Password123!',
+        role: caretakerRoleId,
+      });
+    }
+
+    // Create 3 patients assigned to the seed doctor
+    const [p1, p2, p3] = await Patient.create([
+      {
+        fullname: 'Eleanor Voss',
+        dateOfBirth: new Date('1945-03-12'),
+        gender: 'F',
+        assignedDoctor: doctor._id,
+        caretaker: caretaker._id,
+        dateOfAdmitting: daysAgo(60),
+        description: 'Post-stroke rehabilitation with mobility support.',
+        emergencyContactName: 'Tom Voss',
+        emergencyContactNumber: '+61411000001',
+        nextOfKinName: 'Tom Voss',
+        nextOfKinRelationship: 'CHILD',
+        medicalSummary: 'Ischaemic stroke 2023. Mild left-sided weakness. On anticoagulants.',
+        allergies: ['Aspirin'],
+        conditions: ['Stroke', 'Hypertension'],
+      },
+      {
+        fullname: 'Raymond Park',
+        dateOfBirth: new Date('1950-07-28'),
+        gender: 'M',
+        assignedDoctor: doctor._id,
+        caretaker: caretaker._id,
+        dateOfAdmitting: daysAgo(45),
+        description: 'Diabetic patient requiring insulin management and dietary oversight.',
+        emergencyContactName: 'Susan Park',
+        emergencyContactNumber: '+61411000002',
+        nextOfKinName: 'Susan Park',
+        nextOfKinRelationship: 'SPOUSE',
+        medicalSummary: 'Type 2 Diabetes since 2010. CKD Stage 2. On metformin and insulin.',
+        allergies: ['Sulfa drugs'],
+        conditions: ['Type 2 Diabetes', 'CKD'],
+      },
+      {
+        fullname: 'Margaret Chen',
+        dateOfBirth: new Date('1938-11-04'),
+        gender: 'F',
+        assignedDoctor: doctor._id,
+        caretaker: caretaker._id,
+        dateOfAdmitting: daysAgo(30),
+        description: 'Dementia patient requiring daily cognitive support and monitoring.',
+        emergencyContactName: 'Linda Chen',
+        emergencyContactNumber: '+61411000003',
+        nextOfKinName: 'Linda Chen',
+        nextOfKinRelationship: 'CHILD',
+        medicalSummary: "Moderate Alzheimer's disease. On donepezil. History of falls.",
+        allergies: [],
+        conditions: ["Alzheimer's Disease"],
+      },
+    ]);
+
+    // Mirror patients on doctor's assignedPatients
+    await User.findByIdAndUpdate(doctor._id, {
+      $set: { assignedPatients: [p1._id, p2._id, p3._id] },
+    });
+
+    // Prescriptions (active, completed, discontinued) written by the doctor
+    await Prescription.create([
+      {
+        patient: p1._id,
+        prescriber: doctor._id,
+        status: 'active',
+        notes: 'Monitor BP weekly.',
+        items: [{ name: 'Warfarin', dose: '5mg', frequency: 'daily', durationDays: 90 }],
+      },
+      {
+        patient: p1._id,
+        prescriber: doctor._id,
+        status: 'active',
+        notes: 'For pain management.',
+        items: [{ name: 'Paracetamol', dose: '500mg', frequency: 'twice daily', durationDays: 30 }],
+      },
+      {
+        patient: p2._id,
+        prescriber: doctor._id,
+        status: 'active',
+        notes: 'Check HbA1c monthly.',
+        items: [
+          { name: 'Metformin', dose: '500mg', frequency: 'twice daily', durationDays: 90 },
+          { name: 'Insulin Glargine', dose: '10 units', frequency: 'nightly', durationDays: 90 },
+        ],
+      },
+      {
+        patient: p2._id,
+        prescriber: doctor._id,
+        status: 'completed',
+        notes: 'Short course completed.',
+        items: [{ name: 'Amoxicillin', dose: '250mg', frequency: 'three times daily', durationDays: 7 }],
+      },
+      {
+        patient: p3._id,
+        prescriber: doctor._id,
+        status: 'active',
+        notes: 'Review in 3 months.',
+        items: [{ name: 'Donepezil', dose: '10mg', frequency: 'nightly', durationDays: 90 }],
+      },
+      {
+        patient: p3._id,
+        prescriber: doctor._id,
+        status: 'discontinued',
+        notes: 'Discontinued due to adverse reaction.',
+        items: [{ name: 'Rivastigmine', dose: '3mg', frequency: 'twice daily', durationDays: 60 }],
+      },
+    ]);
+
+    // Tasks for the doctor's patients (completed, pending, overdue)
+    await Task.create([
+      {
+        description: 'Morning blood pressure check',
+        dueDate: daysAgo(5),
+        priority: 'high',
+        status: 'completed',
+        patient: p1._id,
+        caretaker: caretaker._id,
+      },
+      {
+        description: 'Administer warfarin dose',
+        dueDate: daysAgo(3),
+        priority: 'high',
+        status: 'completed',
+        patient: p1._id,
+        caretaker: caretaker._id,
+      },
+      {
+        description: 'Blood glucose reading before lunch',
+        dueDate: daysAgo(2),
+        priority: 'high',
+        status: 'completed',
+        patient: p2._id,
+        caretaker: caretaker._id,
+      },
+      {
+        description: 'Schedule physiotherapy session',
+        dueDate: daysFromNow(3),
+        priority: 'medium',
+        status: 'pending',
+        patient: p1._id,
+        caretaker: caretaker._id,
+      },
+      {
+        description: 'Insulin injection — evening',
+        dueDate: daysFromNow(1),
+        priority: 'high',
+        status: 'pending',
+        patient: p2._id,
+        caretaker: caretaker._id,
+      },
+      {
+        description: 'Cognitive activity session',
+        dueDate: daysFromNow(2),
+        priority: 'medium',
+        status: 'in progress',
+        patient: p3._id,
+        caretaker: caretaker._id,
+      },
+      {
+        description: 'Weekly weight measurement',
+        dueDate: daysAgo(4),
+        priority: 'low',
+        status: 'pending',
+        patient: p2._id,
+        caretaker: caretaker._id,
+      },
+      {
+        description: 'Fall risk reassessment',
+        dueDate: daysAgo(7),
+        priority: 'high',
+        status: 'pending',
+        patient: p3._id,
+        caretaker: caretaker._id,
+      },
+      {
+        description: 'Dietary review with caretaker',
+        dueDate: daysAgo(2),
+        priority: 'medium',
+        status: 'in progress',
+        patient: p3._id,
+        caretaker: caretaker._id,
+      },
+    ]);
+
+    // Recent patient logs (within last 7 days)
+    await PatientLog.create([
+      {
+        title: 'BP elevated — action taken',
+        description: "Eleanor's BP was 155/95. Warfarin dose reviewed and caretaker notified.",
+        patient: p1._id,
+        createdBy: doctor._id,
+        createdAt: daysAgo(1),
+      },
+      {
+        title: 'Post-stroke mobility progress noted',
+        description: 'Eleanor walked 50m unassisted in morning session. Improvement from last week.',
+        patient: p1._id,
+        createdBy: doctor._id,
+        createdAt: daysAgo(3),
+      },
+      {
+        title: 'Blood glucose high — insulin adjusted',
+        description: "Raymond's fasting glucose was 11.2 mmol/L. Insulin dose increased by 2 units.",
+        patient: p2._id,
+        createdBy: doctor._id,
+        createdAt: daysAgo(2),
+      },
+      {
+        title: 'Cognitive assessment completed',
+        description: 'Margaret scored 18/30 on MMSE. Slight decline from last month — family informed.',
+        patient: p3._id,
+        createdBy: doctor._id,
+        createdAt: daysAgo(4),
+      },
+      {
+        title: 'Fall incident reported',
+        description: 'Margaret experienced a minor fall in the bathroom. No injury. Safety rails requested.',
+        patient: p3._id,
+        createdBy: doctor._id,
+        createdAt: daysAgo(6),
+      },
+    ]);
+
+    console.log(`Doctor seed complete — login: ${DOCTOR_EMAIL} / Password123!`);
+  } catch (err) {
+    console.error('Error seeding doctor data:', err.message);
+    throw err;
+  }
+};
+
+module.exports = seedDoctorData;

--- a/src/seedDoctorData.js
+++ b/src/seedDoctorData.js
@@ -2,6 +2,7 @@
 
 const Role = require('./models/Role');
 const User = require('./models/User');
+const Doctor = require('./models/Doctor');
 const Patient = require('./models/Patient');
 const Prescription = require('./models/Prescription');
 const Task = require('./models/Task');
@@ -37,10 +38,23 @@ const seedDoctorData = async () => {
       console.log('🌱 Created seed doctor user.');
     }
 
+    // Remove legacy generic fields from every Doctor document (safe no-op if already absent)
+    await Doctor.updateMany(
+      {},
+      { $unset: { phone: '', gender: '', age: '', address: '' } }
+    );
+
+    // Always upsert the seed doctor profile with doctor-specific fields
+    await Doctor.findOneAndUpdate(
+      { user: doctor._id },
+      { $set: { specialization: 'Geriatrics', licenseNumber: 'MED-2024-001' } },
+      { upsert: true, new: true }
+    );
+
     // Guard on patients — if already seeded, skip data creation
     const existingPatients = await Patient.countDocuments({ assignedDoctor: doctor._id });
     if (existingPatients > 0) {
-      console.log('Doctor seed data already present — skipping.');
+      console.log('⚠️  Doctor seed data already present — skipping patient/prescription/task/log creation.');
       return;
     }
 

--- a/src/seedDoctorData.js
+++ b/src/seedDoctorData.js
@@ -44,10 +44,11 @@ const seedDoctorData = async () => {
       { $unset: { phone: '', gender: '', age: '', address: '' } }
     );
 
-    // Always upsert the seed doctor profile with doctor-specific fields
+    // Seed initial doctor-specific fields only on first insert — $setOnInsert
+    // means existing records (already updated via the API) are never overwritten.
     await Doctor.findOneAndUpdate(
       { user: doctor._id },
-      { $set: { specialization: 'Geriatrics', licenseNumber: 'MED-2024-001' } },
+      { $setOnInsert: { specialization: 'Geriatrics', licenseNumber: 'MED-2024-001' } },
       { upsert: true, new: true }
     );
 

--- a/src/seedStaffData.js
+++ b/src/seedStaffData.js
@@ -1,0 +1,303 @@
+'use strict';
+
+const User = require('./models/User');
+const Patient = require('./models/Patient');
+const Task = require('./models/Task');
+const PatientLog = require('./models/PatientLog');
+
+const daysAgo = (n) => new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+const daysFromNow = (n) => new Date(Date.now() + n * 24 * 60 * 60 * 1000);
+
+const seedStaffData = async () => {
+  try {
+    // Depend on seedData having run first — find the seed staff by email
+    const [jane, mike, alice, bob] = await Promise.all([
+      User.findOne({ email: 'jane@guardian.com' }),
+      User.findOne({ email: 'mike@guardian.com' }),
+      User.findOne({ email: 'alice@guardian.com' }),
+      User.findOne({ email: 'bob@guardian.com' }),
+    ]);
+
+    if (!jane) {
+      console.log('⚠️  Staff seed users not found — run seedData first. Skipping seedStaffData.');
+      return;
+    }
+
+    // Guard: skip if tasks already exist for jane
+    const existing = await Task.countDocuments({ nurse_id: jane._id });
+    if (existing > 0) {
+      console.log('⚠️  Staff task/log seed already present — skipping.');
+      return;
+    }
+
+    console.log('🌱 Seeding staff tasks and patient logs...');
+
+    // Find the patients these staff are assigned to
+    const [patient1, patient2] = await Promise.all([
+      Patient.findOne({ fullname: 'Elderly Patient One' }),
+      Patient.findOne({ fullname: 'Elderly Patient Two' }),
+    ]);
+
+    if (!patient1 || !patient2) {
+      console.log('⚠️  Seed patients not found — run seedData first. Skipping seedStaffData.');
+      return;
+    }
+
+    // Tasks
+    // alice (caretaker) → patient1 | bob (caretaker) → patient2
+    // jane (nurse) → patient1 + patient2 | mike (nurse) → patient2
+    await Task.create([
+      // ── Alice (caretaker1) tasks for patient1 ──────────────────────────────
+      {
+        description: 'Morning medication round',
+        dueDate: daysAgo(4),
+        priority: 'high',
+        status: 'completed',
+        patient: patient1._id,
+        caretaker: alice._id,
+      },
+      {
+        description: 'Assist with physiotherapy exercises',
+        dueDate: daysAgo(2),
+        priority: 'medium',
+        status: 'completed',
+        patient: patient1._id,
+        caretaker: alice._id,
+      },
+      {
+        description: 'Prepare evening meal (low-sodium)',
+        dueDate: daysFromNow(1),
+        priority: 'medium',
+        status: 'pending',
+        patient: patient1._id,
+        caretaker: alice._id,
+      },
+      {
+        description: 'Arrange GP follow-up appointment',
+        dueDate: daysFromNow(3),
+        priority: 'low',
+        status: 'in progress',
+        patient: patient1._id,
+        caretaker: alice._id,
+      },
+      {
+        description: 'Weekly bathroom safety check',
+        dueDate: daysAgo(5),
+        priority: 'high',
+        status: 'pending',
+        patient: patient1._id,
+        caretaker: alice._id,
+      },
+      {
+        description: 'Complete monthly care report',
+        dueDate: daysAgo(3),
+        priority: 'medium',
+        status: 'in progress',
+        patient: patient1._id,
+        caretaker: alice._id,
+      },
+
+      // ── Bob (caretaker2) tasks for patient2 ───────────────────────────────
+      {
+        description: 'Administer insulin injection',
+        dueDate: daysAgo(3),
+        priority: 'high',
+        status: 'completed',
+        patient: patient2._id,
+        caretaker: bob._id,
+      },
+      {
+        description: 'Blood glucose monitoring — morning',
+        dueDate: daysAgo(1),
+        priority: 'high',
+        status: 'completed',
+        patient: patient2._id,
+        caretaker: bob._id,
+      },
+      {
+        description: 'Prepare diabetic-friendly lunch',
+        dueDate: daysFromNow(1),
+        priority: 'medium',
+        status: 'pending',
+        patient: patient2._id,
+        caretaker: bob._id,
+      },
+      {
+        description: 'Log dietary intake for the day',
+        dueDate: daysAgo(6),
+        priority: 'low',
+        status: 'pending',
+        patient: patient2._id,
+        caretaker: bob._id,
+      },
+      {
+        description: 'Foot examination for neuropathy signs',
+        dueDate: daysAgo(4),
+        priority: 'high',
+        status: 'pending',
+        patient: patient2._id,
+        caretaker: bob._id,
+      },
+
+      // ── Jane (nurse1) tasks for patient1 (alice is caretaker) ─────────────
+      {
+        description: 'Blood pressure check and log',
+        dueDate: daysAgo(3),
+        priority: 'high',
+        status: 'completed',
+        patient: patient1._id,
+        caretaker: alice._id,
+        nurse_id: jane._id,
+      },
+      {
+        description: 'Wound dressing change',
+        dueDate: daysAgo(1),
+        priority: 'high',
+        status: 'completed',
+        patient: patient1._id,
+        caretaker: alice._id,
+        nurse_id: jane._id,
+      },
+      {
+        description: 'Vital signs observation — afternoon',
+        dueDate: daysFromNow(2),
+        priority: 'medium',
+        status: 'pending',
+        patient: patient1._id,
+        caretaker: alice._id,
+        nurse_id: jane._id,
+      },
+      {
+        description: 'IV line flush and check',
+        dueDate: daysAgo(5),
+        priority: 'high',
+        status: 'pending',
+        patient: patient1._id,
+        caretaker: alice._id,
+        nurse_id: jane._id,
+      },
+
+      // ── Jane (nurse1) tasks for patient2 (bob is caretaker) ──────────────
+      {
+        description: 'Post-meal glucose reading',
+        dueDate: daysAgo(2),
+        priority: 'high',
+        status: 'completed',
+        patient: patient2._id,
+        caretaker: bob._id,
+        nurse_id: jane._id,
+      },
+      {
+        description: 'HbA1c test preparation',
+        dueDate: daysFromNow(4),
+        priority: 'medium',
+        status: 'in progress',
+        patient: patient2._id,
+        caretaker: bob._id,
+        nurse_id: jane._id,
+      },
+      {
+        description: 'Update patient medication chart',
+        dueDate: daysAgo(7),
+        priority: 'medium',
+        status: 'pending',
+        patient: patient2._id,
+        caretaker: bob._id,
+        nurse_id: jane._id,
+      },
+
+      // ── Mike (nurse2) tasks for patient2 (bob is caretaker) ──────────────
+      {
+        description: 'Evening obs round',
+        dueDate: daysAgo(2),
+        priority: 'high',
+        status: 'completed',
+        patient: patient2._id,
+        caretaker: bob._id,
+        nurse_id: mike._id,
+      },
+      {
+        description: 'Insulin dose adjustment review',
+        dueDate: daysFromNow(2),
+        priority: 'high',
+        status: 'pending',
+        patient: patient2._id,
+        caretaker: bob._id,
+        nurse_id: mike._id,
+      },
+      {
+        description: 'Patient mobility assessment',
+        dueDate: daysAgo(8),
+        priority: 'medium',
+        status: 'pending',
+        patient: patient2._id,
+        caretaker: bob._id,
+        nurse_id: mike._id,
+      },
+    ]);
+
+    // Patient logs (within last 7 days so recentLogsCount > 0)
+    await PatientLog.create([
+      // Jane logs
+      {
+        title: 'BP reading — slightly elevated',
+        description: 'Patient One BP was 148/90. Caretaker notified. Plan to monitor again tomorrow.',
+        patient: patient1._id,
+        createdBy: jane._id,
+        createdAt: daysAgo(1),
+      },
+      {
+        title: 'Wound showing signs of improvement',
+        description: 'Wound site clean with no signs of infection. Dressing changed successfully.',
+        patient: patient1._id,
+        createdBy: jane._id,
+        createdAt: daysAgo(3),
+      },
+      {
+        title: 'Post-meal glucose within target range',
+        description: 'Patient Two glucose 7.4 mmol/L two hours post-lunch. Within acceptable range.',
+        patient: patient2._id,
+        createdBy: jane._id,
+        createdAt: daysAgo(2),
+      },
+      // Mike logs
+      {
+        title: 'Evening obs normal',
+        description: 'All vitals stable. Patient Two resting comfortably. No concerns to report.',
+        patient: patient2._id,
+        createdBy: mike._id,
+        createdAt: daysAgo(1),
+      },
+      {
+        title: 'Insulin dose reviewed',
+        description: 'Discussed insulin timing adjustment with caretaker. Will trial new schedule tomorrow.',
+        patient: patient2._id,
+        createdBy: mike._id,
+        createdAt: daysAgo(4),
+      },
+      // Alice logs
+      {
+        title: 'Physio exercises completed',
+        description: 'Patient One completed morning physiotherapy session with good participation.',
+        patient: patient1._id,
+        createdBy: alice._id,
+        createdAt: daysAgo(2),
+      },
+      // Bob logs
+      {
+        title: 'Dietary log updated',
+        description: 'Patient Two consumed all meals within dietary guidelines. Blood sugar stable post-dinner.',
+        patient: patient2._id,
+        createdBy: bob._id,
+        createdAt: daysAgo(3),
+      },
+    ]);
+
+    console.log('✅ Staff seed complete — tasks and logs created for jane, mike, alice, bob.');
+  } catch (err) {
+    console.error('❌ Error seeding staff data:', err.message);
+    throw err;
+  }
+};
+
+module.exports = seedStaffData;


### PR DESCRIPTION
- Implemented `GET /api/v1/doctors/profile` — returns the logged-in doctor's User account details merged with their Doctor-specific record (`specialization`, `licenseNumber`). Scoped to the authenticated doctor via JWT; no query params required.
- Implemented `PUT /api/v1/doctors/profile` — updates the logged-in doctor's profile. `fullname`/`email` write to the User record (email is normalised to lowercase and checked for uniqueness, returning 409 on conflict); `specialization` and `licenseNumber` upsert into the Doctor collection. Fields are explicitly whitelisted so arbitrary body keys cannot overwrite internal schema fields. No `doctorId` needed in the body.
- Implemented `GET /api/v1/doctors/dashboard-summary` — returns a real-time snapshot scoped to the logged-in doctor: total/active patient counts, prescription status breakdown (active, completed, discontinued), task breakdown (total, completed, in-progress, pending, overdue), and recent care activity (patient logs in last 7 days).
- Created `Doctor` model (`src/models/Doctor.js`) to store doctor-specific profile fields (`specialization`, `licenseNumber`) in a separate collection linked to `User` by ObjectId, keeping the shared `User` schema clean and unaffected for other roles. Future sprints can extend this with fields like `qualifications`, `yearsOfExperience`, `clinicName`, or `languages` that only apply to doctors.
- Fixed all patient queries across the doctor controller to use `assignedDoctor` (correct Patient model field name) instead of `doctor`, including the `listPatientsByDoctor` select and its Swagger description.
- Added `seedDoctorData.js` with realistic test data: 3 patients (Eleanor Voss, Raymond Park, Margaret Chen), 6 prescriptions across all statuses, 9 tasks including overdue ones, and 5 recent patient logs. On every startup: strips legacy generic fields (`phone`, `gender`, `age`, `address`) from all Doctor documents via `$unset`, and seeds `specialization`/`licenseNumber` using `$setOnInsert` so existing records updated via the API are never overwritten. Guards independently on patient count so it runs even when other seeds have already executed.
- Updated `seedData.js` guard to check for seed patients existing instead of a blanket user count, and made user creation idempotent (`findOrCreate`), so partial seeds (users created but patients failed) are safely retried on next restart without duplicate-key errors.
- Extended nurse, caretaker, and admin `dashboard-summary` endpoints with `inProgressTasks`, `overdueTasks`, and `taskCompletionRate`; fixed `pendingTasks` calculation to correctly exclude in-progress tasks; added `recentLogsCount` (logs in last 7 days) and a staff breakdown (total, doctors, nurses, caretakers, pendingApprovals) to the admin summary. Added `seedStaffData.js` to populate realistic tasks and patient logs for all seed staff so all dashboard endpoints return meaningful data out of the box.
- Added full Swagger documentation for all new and updated endpoints including response schemas, field descriptions, `pattern` format for `licenseNumber`, 409 conflict response on email update, and request body examples using the seed doctor credentials.

## Description

Adds the doctor profile and dashboard summary feature. Doctor-specific profile data (phone, gender, age, address) is stored in a new dedicated `Doctor` collection rather than on the shared `User` model to avoid polluting fields used by other roles. All three endpoints are scoped to the authenticated doctor via JWT. Seed data is included so the dashboard summary returns meaningful data immediately on first run.

### Todos

- [X] Tested and working locally
- [X] Code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] Code changes documented
- [X] Requested review from >= 1 devs on the team

### How to test
#### Doctor-Related Endpoints
1. Start the server — `seedDoctorData` runs automatically and logs `Doctor seed complete`
2. Login: `POST /api/v1/auth/login` with `dr.seed@guardian.com` / `Password123!` to get a token
3. `GET /api/v1/doctors/profile` — returns User details + empty `profile` object (until updated)
4. `PUT /api/v1/doctors/profile` with `{ "phone": "04082234", "gender": "M", "age": 35, "address": "123 Health St" }` — creates the Doctor record
5. `GET /api/v1/doctors/profile` again — `profile` now contains the updated fields
6. `GET /api/v1/doctors/dashboard-summary` — returns:
   - `totalPatients: 3`, `totalActivePatients: 3`
   - `prescriptions: { total: 6, active: 4, completed: 1, discontinued: 1 }`
   - `tasks: { total: 9, completed: 3, pending: 6, overdue: 3 }`
   - `recentLogsCount: 5`

#### Admin Summaries
Can use following seeded data

Role | Email
-- | --
Nurse 1 | jane@guardian.com
Nurse 2 | mike@guardian.com
Caretaker 1 | alice@guardian.com
Caretaker 2 | bob@guardian.com
Doctor | dr.seed@guardian.com

### Screenshots and/or Gifs
`GET /api/v1/doctors/profile`
<img width="1175" height="748" alt="Screenshot 2026-05-12 at 12 49 47 PM" src="https://github.com/user-attachments/assets/1b7fea24-e13c-4d21-9c6a-31baa204a212" />


`PUT /api/v1/doctors/profile`
<img width="1119" height="435" alt="Screenshot 2026-05-12 at 12 50 35 PM" src="https://github.com/user-attachments/assets/8ed5ec35-2140-4e35-b288-10ea8ef610ef" />


**AFTER UPDATE**: `GET /api/v1/doctors/profile`
<img width="1211" height="746" alt="Screenshot 2026-05-12 at 1 08 56 PM" src="https://github.com/user-attachments/assets/2a304fd2-be9a-43fe-b251-13b16e856898" />

`GET /api/v1/doctors/dashboard-summary`
<img width="1037" height="658" alt="image" src="https://github.com/user-attachments/assets/330c60e7-04aa-4911-a298-36b874f050df" />

`GET /api/v1/nurse/dashboard-summary`
<img width="1064" height="855" alt="image" src="https://github.com/user-attachments/assets/7569a674-e70f-4286-aeb8-2b441a8eb86c" />

`GET /api/v1/caretaker/dashboard-summary`
<img width="1068" height="822" alt="image" src="https://github.com/user-attachments/assets/741926ff-57c2-4f02-bfd3-72965a865def" />

Updated Swagger files
<img width="1204" height="228" alt="Screenshot 2026-05-12 at 12 51 28 PM" src="https://github.com/user-attachments/assets/74915950-0e3b-4557-a577-bc365bed1fa2" />
<img width="1184" height="219" alt="Screenshot 2026-05-12 at 12 51 35 PM" src="https://github.com/user-attachments/assets/81c64819-01ce-472b-a71d-ebd7a57a8fef" />


### Associated MS Planner Tasks

- [Doctor Profile and Dashboard Summary](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/mytasks?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fv1%2Fassignedtome%2Fview%2Fboard%2Ftask%2FG022sOLAW0WUygXchCv5cMgAL_94%22%7D)

### Known Issues

[Describe any known issue with this change]