### PR TITLE
Improve patient log APIs with pagination and update support

### DIFF
--- a/src/controllers/caretakerController.js
+++ b/src/controllers/caretakerController.js
@@ -380,7 +380,7 @@ exports.getReportsByPatient = async (req, res) => {
   } catch (error) {
     res.status(500).json({ error: 'Error fetching reports', details: error.message });
   }
-
+}
 // Caretaker dashboard summary 
 /**
  * @swagger

--- a/src/controllers/patientLogController.js
+++ b/src/controllers/patientLogController.js
@@ -6,7 +6,7 @@ const PatientLog = require('../models/PatientLog');
  * /api/v1/patient-logs:
  *   post:
  *     summary: Create a patient log entry
- *     description: Allows a nurse to create a log entry for a specific patient.
+ *     description: Allows a nurse, caretaker, or doctor to create a log entry for a patient.
  *     tags: [Patient Logs]
  *     security:
  *       - bearerAuth: []
@@ -23,43 +23,33 @@ const PatientLog = require('../models/PatientLog');
  *             properties:
  *               title:
  *                 type: string
- *                 example: Patient fainted briefly
+ *                 example: Patient mood update
  *               description:
  *                 type: string
- *                 example: Patient lost consciousness for about 10 seconds after standing up quickly. Recovered without intervention.
+ *                 example: Patient was calm and responsive during the morning check.
  *               patient:
  *                 type: string
- *                 example: 688de2621911784a80507314
+ *                 example: 69b77c228345cdf421d22ba3
  *     responses:
  *       201:
  *         description: Log created successfully
  *       400:
  *         description: Missing required fields
+ *       401:
+ *         description: Unauthorized or missing token
+ *       403:
+ *         description: Access denied due to insufficient role
  *       500:
  *         description: Internal server error
- *
- *     x-testing-guide:
- *       instructions: |
- *         1. First, register or login using a nurse account via `/api/v1/auth/register` or `/api/v1/auth/login`.
- *         2. Copy the returned token from the login response.
- *         3. In your testing tool, include the token in the header:
- *            Authorization: Bearer {your_token_here}
- *         4. Send a POST request to `/api/v1/patient-logs` with body:
- *            {
- *              "title": "briefly describe what happened",
- *              "description": "detailed description",
- *              "patient": "patient id"
- *            }
  */
-
-
-
 exports.createLog = async (req, res) => {
   try {
     const { title, description, patient } = req.body;
 
     if (!title || !description || !patient) {
-      return res.status(400).json({ error: 'Title, description, and patient ID are required.' });
+      return res.status(400).json({
+        error: 'Title, description, and patient ID are required.'
+      });
     }
 
     const newLog = await PatientLog.create({
@@ -69,7 +59,10 @@ exports.createLog = async (req, res) => {
       createdBy: req.user._id
     });
 
-    res.status(201).json({ message: 'Log created successfully', log: newLog });
+    res.status(201).json({
+      message: 'Log created successfully',
+      log: newLog
+    });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -79,8 +72,8 @@ exports.createLog = async (req, res) => {
  * @swagger
  * /api/v1/patient-logs/{patientId}:
  *   get:
- *     summary: Get logs by patient ID
- *     description: Returns a list of log entries for a specific patient.
+ *     summary: Get patient logs with pagination
+ *     description: Returns paginated log entries for a specific patient. Accessible by admin, nurse, caretaker, and doctor.
  *     tags: [Patient Logs]
  *     security:
  *       - bearerAuth: []
@@ -91,51 +84,191 @@ exports.createLog = async (req, res) => {
  *         schema:
  *           type: string
  *         description: The ID of the patient
- *         example: 688de2621911784a80507314
+ *         example: 69b77c228345cdf421d22ba3
+ *       - in: query
+ *         name: page
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: Page number for pagination
+ *       - in: query
+ *         name: limit
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 20
+ *         description: Number of logs per page. Maximum allowed value is 100.
+ *       - in: query
+ *         name: sort
+ *         required: false
+ *         schema:
+ *           type: string
+ *           default: -createdAt
+ *           example: -createdAt
+ *         description: Sort order for logs. Use -createdAt for newest first or createdAt for oldest first.
  *     responses:
  *       200:
  *         description: Logs fetched successfully
  *         content:
  *           application/json:
  *             schema:
- *               type: array
- *               items:
- *                 type: object
- *                 properties:
- *                   _id:
- *                     type: string
- *                   title:
- *                     type: string
- *                   description:
- *                     type: string
- *                   createdBy:
+ *               type: object
+ *               properties:
+ *                 page:
+ *                   type: integer
+ *                   example: 1
+ *                 limit:
+ *                   type: integer
+ *                   example: 20
+ *                 total:
+ *                   type: integer
+ *                   example: 3
+ *                 totalPages:
+ *                   type: integer
+ *                   example: 1
+ *                 data:
+ *                   type: array
+ *                   items:
  *                     type: object
  *                     properties:
- *                       fullname:
+ *                       _id:
  *                         type: string
- *                       role:
+ *                       title:
  *                         type: string
- *                   createdAt:
- *                     type: string
- *     x-testing-guide:
- *       instructions: |
- *         1. Login as any valid user with access to patient logs (e.g., nurse or caretaker).
- *         2. Use the JWT token in the header:
- *            Authorization: Bearer <your_token_here>
- *         3. Send a GET request to:
- *            /api/v1/patient-logs/688de2621911784a80507314
+ *                       description:
+ *                         type: string
+ *                       patient:
+ *                         type: string
+ *                       createdBy:
+ *                         type: object
+ *                       createdAt:
+ *                         type: string
+ *       401:
+ *         description: Unauthorized or missing token
+ *       403:
+ *         description: Access denied due to insufficient role
+ *       500:
+ *         description: Internal server error
  */
-
-
-
 exports.getLogsByPatient = async (req, res) => {
   try {
     const { patientId } = req.params;
-    const logs = await PatientLog.find({ patient: patientId })
-      .populate('createdBy', 'fullname role')
-      .sort({ createdAt: -1 });
 
-    res.status(200).json(logs);
+    const page = Math.max(parseInt(req.query.page, 10) || 1, 1);
+    const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 20, 1), 100);
+    const sort = req.query.sort || '-createdAt';
+
+    const skip = (page - 1) * limit;
+
+    const [logs, total] = await Promise.all([
+      PatientLog.find({ patient: patientId })
+        .populate('createdBy', 'fullname role')
+        .sort(sort)
+        .skip(skip)
+        .limit(limit),
+      PatientLog.countDocuments({ patient: patientId })
+    ]);
+
+    res.status(200).json({
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit),
+      data: logs
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+/**
+ * @swagger
+ * /api/v1/patient-logs/{id}:
+ *   put:
+ *     summary: Update a patient log entry
+ *     description: Updates a patient log entry. Only the original creator or an admin can update the log.
+ *     tags: [Patient Logs]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the log entry to update
+ *         example: 69c123456789abcdef123456
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               title:
+ *                 type: string
+ *                 example: Updated patient mood update
+ *               description:
+ *                 type: string
+ *                 example: Patient was calm and responsive after breakfast.
+ *     responses:
+ *       200:
+ *         description: Log updated successfully
+ *       400:
+ *         description: At least title or description is required
+ *       401:
+ *         description: Unauthorized or missing token
+ *       403:
+ *         description: Permission denied. Only the creator or admin can update this log.
+ *       404:
+ *         description: Log not found
+ *       500:
+ *         description: Internal server error
+ */
+exports.updateLog = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { title, description } = req.body;
+
+    if (!title && !description) {
+      return res.status(400).json({
+        error: 'At least title or description is required.'
+      });
+    }
+
+    const log = await PatientLog.findById(id);
+
+    if (!log) {
+      return res.status(404).json({
+        error: 'Log not found'
+      });
+    }
+
+    const userId = req.user._id || req.user.id;
+    const userRole = req.user?.role?.name || req.user?.role;
+
+    const isCreator = log.createdBy.toString() === userId.toString();
+    const isAdmin = userRole === 'admin';
+
+    if (!isCreator && !isAdmin) {
+      return res.status(403).json({
+        error: 'Permission denied. Only the creator or admin can update this log.'
+      });
+    }
+
+    if (title) log.title = title;
+    if (description) log.description = description;
+
+    const updatedLog = await log.save();
+
+    res.status(200).json({
+      message: 'Log updated successfully',
+      log: updatedLog
+    });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -145,8 +278,8 @@ exports.getLogsByPatient = async (req, res) => {
  * @swagger
  * /api/v1/patient-logs/{id}:
  *   delete:
- *     summary: Delete a log entry
- *     description: Deletes a patient log. Only the creator or admin can delete it.
+ *     summary: Delete a patient log entry
+ *     description: Deletes a patient log entry. Only the original creator or an admin can delete the log.
  *     tags: [Patient Logs]
  *     security:
  *       - bearerAuth: []
@@ -157,39 +290,48 @@ exports.getLogsByPatient = async (req, res) => {
  *         schema:
  *           type: string
  *         description: The ID of the log entry to delete
+ *         example: 69c123456789abcdef123456
  *     responses:
  *       200:
  *         description: Log deleted successfully
+ *       401:
+ *         description: Unauthorized or missing token
  *       403:
- *         description: Permission denied
+ *         description: Permission denied. Only the creator or admin can delete this log.
  *       404:
  *         description: Log not found
  *       500:
  *         description: Internal server error
- *
- *     x-testing-guide:
- *       instructions: |
- *         1. Login as the nurse who created the log, or as an admin.
- *         2. Use the token in header:
- *            Authorization: Bearer {your_token_here}
- *         3. Send DELETE request to:
- *            /api/v1/patient-logs/<log_id>
  */
-
-
 exports.deleteLog = async (req, res) => {
   try {
     const { id } = req.params;
+
     const log = await PatientLog.findById(id);
 
-    if (!log) return res.status(404).json({ error: 'Log not found' });
+    if (!log) {
+      return res.status(404).json({
+        error: 'Log not found'
+      });
+    }
 
-    if (!log.createdBy.equals(req.user._id) && req.user.role !== 'admin') {
-      return res.status(403).json({ error: 'Permission denied' });
+    const userId = req.user._id || req.user.id;
+    const userRole = req.user?.role?.name || req.user?.role;
+
+    const isCreator = log.createdBy.toString() === userId.toString();
+    const isAdmin = userRole === 'admin';
+
+    if (!isCreator && !isAdmin) {
+      return res.status(403).json({
+        error: 'Permission denied. Only the creator or admin can delete this log.'
+      });
     }
 
     await PatientLog.findByIdAndDelete(id);
-    res.status(200).json({ message: 'Log deleted successfully' });
+
+    res.status(200).json({
+      message: 'Log deleted successfully'
+    });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/src/controllers/patientLogController.js
+++ b/src/controllers/patientLogController.js
@@ -1,5 +1,57 @@
 // controllers/patientLogController.js
+const mongoose = require('mongoose');
 const PatientLog = require('../models/PatientLog');
+const Patient = require('../models/Patient');
+const User = require('../models/User');
+const getUserId = (req) => req.user?._id || req.user?.id;
+const getRoleName = async (req) => {
+  if (req.user?.role?.name) {
+    return req.user.role.name;
+  }
+  if (req.user?.role && typeof req.user.role === 'string' && !mongoose.isValidObjectId(req.user.role)) {
+    return req.user.role;
+  }
+  const userId = getUserId(req);
+  const user = await User.findById(userId)
+    .populate('role', 'name')
+    .select('role')
+    .lean();
+  return user?.role?.name || user?.role;
+};
+const isSameId = (a, b) => { return a && b && a.toString() === b.toString();};
+
+const canModifyLog = async (log, req) => { 
+  const userId = getUserId(req);
+  const roleName = await getRoleName(req);
+  return isSameId(log.createdBy, userId) || roleName === 'admin';
+};
+
+const canAccessPatientLogs = async (patientId, req) => {
+  const userId = getUserId(req);
+  const roleName = await getRoleName(req);
+
+  if (roleName === 'admin') return true;
+
+  const patient = await Patient.findById(patientId)
+    .select('caretaker assignedNurses assignedDoctor')
+    .lean();
+
+  if (!patient) return false;
+
+  if (roleName === 'caretaker') {
+    return isSameId(patient.caretaker, userId);
+  }
+
+  if (roleName === 'nurse') {
+    return patient.assignedNurses?.some((nurseId) => isSameId(nurseId, userId));
+  }
+
+  if (roleName === 'doctor') {
+    return isSameId(patient.assignedDoctor, userId);
+  }
+
+  return false;
+};
 
 /**
  * @swagger
@@ -158,9 +210,26 @@ exports.getLogsByPatient = async (req, res) => {
   try {
     const { patientId } = req.params;
 
+    if (!mongoose.isValidObjectId(patientId)) {
+      return res.status(400).json({
+      error: 'Invalid patient ID.'
+      });
+    }
+
+    const hasAccess = await canAccessPatientLogs(patientId, req);
+
+    if (!hasAccess) {
+        return res.status(403).json({
+        error: 'Permission denied. You do not have access to this patient logs.'
+        });
+    }
+
     const page = Math.max(parseInt(req.query.page, 10) || 1, 1);
     const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 20, 1), 100);
-    const sort = req.query.sort || '-createdAt';
+    const allowedSortValues = ['createdAt', '-createdAt'];
+    const sort = allowedSortValues.includes(req.query.sort)
+      ? req.query.sort
+      : '-createdAt';
 
     const skip = (page - 1) * limit;
 
@@ -233,6 +302,11 @@ exports.updateLog = async (req, res) => {
   try {
     const { id } = req.params;
     const { title, description } = req.body;
+    if (!mongoose.isValidObjectId(id)) {
+      return res.status(400).json({
+      error: 'Invalid log ID.'
+      });
+    }
 
     if (!title && !description) {
       return res.status(400).json({
@@ -248,20 +322,17 @@ exports.updateLog = async (req, res) => {
       });
     }
 
-    const userId = req.user._id || req.user.id;
-    const userRole = req.user?.role?.name || req.user?.role;
-
-    const isCreator = log.createdBy.toString() === userId.toString();
-    const isAdmin = userRole === 'admin';
-
-    if (!isCreator && !isAdmin) {
+    if (!(await canModifyLog(log, req))) {
       return res.status(403).json({
-        error: 'Permission denied. Only the creator or admin can update this log.'
+      error: 'Permission denied. Only the creator or admin can update this log.'
       });
     }
 
     if (title) log.title = title;
     if (description) log.description = description;
+
+    log.updatedBy = getUserId(req);
+    log.updatedAt = new Date();
 
     const updatedLog = await log.save();
 
@@ -306,6 +377,11 @@ exports.updateLog = async (req, res) => {
 exports.deleteLog = async (req, res) => {
   try {
     const { id } = req.params;
+    if (!mongoose.isValidObjectId(id)) {
+      return res.status(400).json({
+      error: 'Invalid log ID.'
+      });
+    }
 
     const log = await PatientLog.findById(id);
 
@@ -315,13 +391,7 @@ exports.deleteLog = async (req, res) => {
       });
     }
 
-    const userId = req.user._id || req.user.id;
-    const userRole = req.user?.role?.name || req.user?.role;
-
-    const isCreator = log.createdBy.toString() === userId.toString();
-    const isAdmin = userRole === 'admin';
-
-    if (!isCreator && !isAdmin) {
+    if (!(await canModifyLog(log, req))) {
       return res.status(403).json({
         error: 'Permission denied. Only the creator or admin can delete this log.'
       });

--- a/src/models/PatientLog.js
+++ b/src/models/PatientLog.js
@@ -5,7 +5,9 @@ const PatientLogSchema = new mongoose.Schema({
   title: { type: String, required: true },
   description: { type: String, required: true },
   patient: { type: mongoose.Schema.Types.ObjectId, ref: 'Patient', required: true },
-  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true }, // nurse or caretaker
+  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  updatedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  updatedAt: { type: Date},
   createdAt: { type: Date, default: Date.now }
 });
 

--- a/src/routes/patientLogRoutes.js
+++ b/src/routes/patientLogRoutes.js
@@ -1,17 +1,21 @@
 // routes/patientLogRoutes.js
 const express = require('express');
 const router = express.Router();
+
 const verifyToken = require('../middleware/verifyToken');
 const verifyRole = require('../middleware/verifyRole');
 const controller = require('../controllers/patientLogController');
 
-// add log
+// Create patient log
 router.post('/',verifyToken,verifyRole(['nurse', 'caretaker', 'doctor']),controller.createLog);
 
-// get log
-router.get('/:patientId',verifyToken,verifyRole(['nurse', 'caretaker', 'doctor', 'admin']),controller.getLogsByPatient);
+// Fetch logs by patient with pagination
+router.get('/:patientId',verifyToken,verifyRole(['admin', 'nurse', 'caretaker', 'doctor']),controller.getLogsByPatient);
 
-// deleting log
-router.delete('/:id', verifyToken, controller.deleteLog);
+// Update patient log
+router.put('/:id',verifyToken,verifyRole(['admin', 'nurse', 'caretaker', 'doctor']),controller.updateLog);
+
+// Delete patient log
+router.delete('/:id',verifyToken,verifyRole(['admin', 'nurse', 'caretaker', 'doctor']),controller.deleteLog);
 
 module.exports = router;


### PR DESCRIPTION
## Description

Implemented Sprint 2 Task 6 - Patient Log Improvements.

Changes made:
- Updated patient log POST route to use verifyRole array syntax.
- Added pagination to getLogsByPatient using page, limit, and sort query parameters.
- Updated GET response format to return page, limit, total, totalPages, and data.
- Added PUT /api/v1/patient-logs/:id endpoint for updating patient logs.
- Added permission check so only the original creator or admin can update a log.
- Mounted the new PUT route with verifyToken and role restrictions.
- Updated Swagger documentation for GET pagination and the new PUT endpoint.

Testing completed:
- Tested GET /api/v1/patient-logs/:patientId with pagination.
- Confirmed paginated response returns page, limit, total, totalPages, and data.
- Tested PUT update log as creator/admin.
- Confirmed non-creator non-admin receives 403 when trying to update someone else’s log.
- Confirmed existing create and delete behaviour is unchanged.

### Todos

- [ ] Tested and working locally - Yes
- [ ] Code follows the style guidelines of this project - Yes
- [ ] I have performed a self-review of my code
- [ ] Code changes documented
- [ ] Requested review from >= 1 devs on the team

### How to test

Use the Screenshots attached to test it.

### Screenshots and/or Gifs

<img width="1548" height="521" alt="image" src="https://github.com/user-attachments/assets/3650a0ec-72e7-4856-9a76-85c2cc242e4a" />
<img width="1858" height="814" alt="image" src="https://github.com/user-attachments/assets/29a60de4-1c86-4996-8e90-1c8123210ee3" />

