### PR TITLE
Task 2: Add CarePlan CRUD endpoints

### DIFF
--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -98,7 +98,9 @@ exports.getPatientOverview = async (req, res) => {
 
     const healthRecords = await HealthRecord.find({ patient: patientId });
     const tasks = await Task.find({ patient: patientId });
-    const carePlan = await CarePlan.findOne({ patient: patientId }).populate('tasks');
+    const carePlan = await CarePlan.findOne({ patient: patientId, status: 'active' })
+      .sort({ created_at: -1 })
+      .populate('tasks');
 
     const taskCompletionRate = tasks.length
       ? (tasks.filter(task => task.status === 'completed').length / tasks.length) * 100

--- a/src/controllers/adminPatientController.js
+++ b/src/controllers/adminPatientController.js
@@ -941,7 +941,7 @@ exports.patientOverview = async (req, res) => {
 
     const [healthRecords, carePlan, tasks, logs] = await Promise.all([
       HealthRecord.find({ patient: id }).sort({ created_at: -1 }).lean(),
-      CarePlan.findOne({ patient: id }).populate('tasks').lean(),
+      CarePlan.findOne({ patient: id, status: 'active' }).sort({ created_at: -1 }).populate('tasks').lean(),
       Task.find({ patient: id }).lean(),
       EntryReport.find({ patient: id }).sort({ activityTimestamp: -1 }).lean(),
     ]);

--- a/src/controllers/carePlanController.js
+++ b/src/controllers/carePlanController.js
@@ -1,0 +1,251 @@
+const mongoose = require('mongoose');
+const CarePlan = require('../models/CarePlan');
+const Patient = require('../models/Patient');
+const Task = require('../models/Task');
+const { ensureUserWithRole } = require('../services/userService');
+
+const POPULATE_OPTIONS = [
+  { path: 'tasks' },
+  { path: 'patient', select: 'fullname gender dateOfBirth' },
+  { path: 'caretaker', select: 'fullname email' },
+  { path: 'nurse', select: 'fullname email' }
+];
+
+function isValidObjectId(value) {
+  return mongoose.Types.ObjectId.isValid(String(value || ''));
+}
+
+function populateCarePlan(query) {
+  POPULATE_OPTIONS.forEach(option => query.populate(option));
+  return query;
+}
+
+async function validateTaskIds(taskIds, patientId) {
+  if (!Array.isArray(taskIds)) {
+    return { ok: false, message: 'tasks must be an array of task IDs' };
+  }
+
+  if (!taskIds.every(isValidObjectId)) {
+    return { ok: false, message: 'tasks must contain valid task IDs' };
+  }
+
+  const matchingTasks = await Task.countDocuments({
+    _id: { $in: taskIds },
+    patient: patientId
+  });
+
+  if (matchingTasks !== taskIds.length) {
+    return { ok: false, message: 'Every task must exist and belong to the selected patient' };
+  }
+
+  return { ok: true };
+}
+
+exports.createCarePlan = async (req, res) => {
+  try {
+    const { title, description = '', patientId, caretakerId, nurseId = null, tasks = [] } = req.body || {};
+
+    if (!title || !patientId || !caretakerId) {
+      return res.status(400).json({ message: 'title, patientId and caretakerId are required' });
+    }
+
+    if (![patientId, caretakerId, ...(nurseId ? [nurseId] : [])].every(isValidObjectId)) {
+      return res.status(400).json({ message: 'patientId, caretakerId and nurseId must be valid IDs' });
+    }
+
+    const patient = await Patient.findById(patientId);
+    if (!patient) return res.status(404).json({ message: 'Patient not found' });
+
+    const caretaker = await ensureUserWithRole(caretakerId, 'caretaker');
+    if (!caretaker) return res.status(400).json({ message: 'caretakerId must reference a caretaker user' });
+
+    let nurse = null;
+    if (nurseId) {
+      nurse = await ensureUserWithRole(nurseId, 'nurse');
+      if (!nurse) return res.status(400).json({ message: 'nurseId must reference a nurse user' });
+    }
+
+    const taskValidation = await validateTaskIds(tasks, patientId);
+    if (!taskValidation.ok) return res.status(400).json({ message: taskValidation.message });
+
+    const existingActivePlan = await CarePlan.findOne({ patient: patientId, status: 'active' });
+    if (existingActivePlan) {
+      return res.status(409).json({
+        message: 'An active care plan already exists for this patient',
+        carePlanId: existingActivePlan._id
+      });
+    }
+
+    const carePlan = await CarePlan.create({
+      title,
+      description,
+      patient: patientId,
+      caretaker: caretaker._id,
+      nurse: nurse?._id || null,
+      tasks,
+      status: 'active'
+    });
+
+    const created = await populateCarePlan(CarePlan.findById(carePlan._id));
+    return res.status(201).json({ message: 'Care plan created', carePlan: created });
+  } catch (error) {
+    if (error.code === 11000) {
+      return res.status(409).json({ message: 'An active care plan already exists for this patient' });
+    }
+    return res.status(500).json({ message: 'Error creating care plan', details: error.message });
+  }
+};
+
+exports.getCarePlans = async (req, res) => {
+  try {
+    const { patientId, status, page = '1', limit = '20' } = req.query;
+    const filter = {};
+
+    if (patientId) {
+      if (!isValidObjectId(patientId)) return res.status(400).json({ message: 'patientId must be a valid ID' });
+      filter.patient = patientId;
+    }
+
+    if (status) {
+      if (!['active', 'inactive'].includes(status)) {
+        return res.status(400).json({ message: 'status must be active or inactive' });
+      }
+      filter.status = status;
+    }
+
+    const pageNum = Math.max(parseInt(page, 10) || 1, 1);
+    const limitNum = Math.min(Math.max(parseInt(limit, 10) || 20, 1), 100);
+    const skip = (pageNum - 1) * limitNum;
+
+    const [items, total] = await Promise.all([
+      populateCarePlan(
+        CarePlan.find(filter)
+          .sort({ created_at: -1 })
+          .skip(skip)
+          .limit(limitNum)
+      ),
+      CarePlan.countDocuments(filter)
+    ]);
+
+    return res.status(200).json({
+      items,
+      pagination: {
+        total,
+        page: pageNum,
+        pages: Math.ceil(total / limitNum),
+        limit: limitNum
+      }
+    });
+  } catch (error) {
+    return res.status(500).json({ message: 'Error fetching care plans', details: error.message });
+  }
+};
+
+exports.getCarePlanById = async (req, res) => {
+  try {
+    const { carePlanId } = req.params;
+    if (!isValidObjectId(carePlanId)) {
+      return res.status(400).json({ message: 'carePlanId must be a valid ID' });
+    }
+
+    const carePlan = await populateCarePlan(CarePlan.findById(carePlanId));
+    if (!carePlan) return res.status(404).json({ message: 'Care plan not found' });
+
+    return res.status(200).json({ carePlan });
+  } catch (error) {
+    return res.status(500).json({ message: 'Error fetching care plan', details: error.message });
+  }
+};
+
+exports.updateCarePlan = async (req, res) => {
+  try {
+    const { carePlanId } = req.params;
+    const { title, description, caretakerId, nurseId, tasks, status } = req.body || {};
+
+    if (!isValidObjectId(carePlanId)) {
+      return res.status(400).json({ message: 'carePlanId must be a valid ID' });
+    }
+
+    const current = await CarePlan.findById(carePlanId);
+    if (!current) return res.status(404).json({ message: 'Care plan not found' });
+
+    const updateData = {};
+    if (title !== undefined) updateData.title = title;
+    if (description !== undefined) updateData.description = description;
+
+    if (caretakerId !== undefined) {
+      if (!isValidObjectId(caretakerId)) return res.status(400).json({ message: 'caretakerId must be a valid ID' });
+      const caretaker = await ensureUserWithRole(caretakerId, 'caretaker');
+      if (!caretaker) return res.status(400).json({ message: 'caretakerId must reference a caretaker user' });
+      updateData.caretaker = caretaker._id;
+    }
+
+    if (nurseId !== undefined) {
+      if (nurseId !== null && !isValidObjectId(nurseId)) {
+        return res.status(400).json({ message: 'nurseId must be a valid ID or null' });
+      }
+      if (nurseId === null) {
+        updateData.nurse = null;
+      } else {
+        const nurse = await ensureUserWithRole(nurseId, 'nurse');
+        if (!nurse) return res.status(400).json({ message: 'nurseId must reference a nurse user' });
+        updateData.nurse = nurse._id;
+      }
+    }
+
+    if (tasks !== undefined) {
+      const taskValidation = await validateTaskIds(tasks, current.patient);
+      if (!taskValidation.ok) return res.status(400).json({ message: taskValidation.message });
+      updateData.tasks = tasks;
+    }
+
+    if (status !== undefined) {
+      if (!['active', 'inactive'].includes(status)) {
+        return res.status(400).json({ message: 'status must be active or inactive' });
+      }
+
+      if (status === 'active' && current.status !== 'active') {
+        const existingActivePlan = await CarePlan.findOne({
+          patient: current.patient,
+          status: 'active',
+          _id: { $ne: current._id }
+        });
+        if (existingActivePlan) {
+          return res.status(409).json({
+            message: 'Another active care plan already exists for this patient',
+            carePlanId: existingActivePlan._id
+          });
+        }
+      }
+
+      updateData.status = status;
+    }
+
+    const carePlan = await populateCarePlan(
+      CarePlan.findByIdAndUpdate(carePlanId, updateData, { new: true, runValidators: true })
+    );
+
+    return res.status(200).json({ message: 'Care plan updated', carePlan });
+  } catch (error) {
+    if (error.code === 11000) {
+      return res.status(409).json({ message: 'Another active care plan already exists for this patient' });
+    }
+    return res.status(500).json({ message: 'Error updating care plan', details: error.message });
+  }
+};
+
+exports.deleteCarePlan = async (req, res) => {
+  try {
+    const { carePlanId } = req.params;
+    if (!isValidObjectId(carePlanId)) {
+      return res.status(400).json({ message: 'carePlanId must be a valid ID' });
+    }
+
+    const carePlan = await CarePlan.findByIdAndDelete(carePlanId);
+    if (!carePlan) return res.status(404).json({ message: 'Care plan not found' });
+
+    return res.status(200).json({ message: 'Care plan deleted' });
+  } catch (error) {
+    return res.status(500).json({ message: 'Error deleting care plan', details: error.message });
+  }
+};

--- a/src/models/CarePlan.js
+++ b/src/models/CarePlan.js
@@ -1,13 +1,32 @@
 const mongoose = require('mongoose');
 
-
 const CarePlanSchema = new mongoose.Schema({
-  tasks: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Task' }], // List of tasks
+  title: { type: String, required: true, trim: true },
+  description: { type: String, default: '', trim: true },
+  tasks: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Task' }],
   patient: { type: mongoose.Schema.Types.ObjectId, ref: 'Patient', required: true },
-  caretaker: { type: mongoose.Schema.Types.ObjectId, ref: 'Caretaker', required: true },
-  nurse: { type: mongoose.Schema.Types.ObjectId, ref: 'Nurse', required: true },
-  created_at: { type: Date, default: Date.now }
+  caretaker: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  nurse: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+  status: { type: String, enum: ['active', 'inactive'], default: 'active' },
+  created_at: { type: Date, default: Date.now },
+  updated_at: { type: Date, default: Date.now }
 });
+
+CarePlanSchema.pre('save', function (next) {
+  this.updated_at = Date.now();
+  next();
+});
+
+CarePlanSchema.pre('findOneAndUpdate', function (next) {
+  this.set({ updated_at: Date.now() });
+  next();
+});
+
+CarePlanSchema.index(
+  { patient: 1, status: 1 },
+  { unique: true, partialFilterExpression: { status: 'active' } }
+);
+CarePlanSchema.index({ patient: 1, created_at: -1 });
 
 const CarePlan = mongoose.model('CarePlan', CarePlanSchema);
 

--- a/src/routes/carePlanRoutes.js
+++ b/src/routes/carePlanRoutes.js
@@ -1,0 +1,384 @@
+const express = require('express');
+const router = express.Router();
+const verifyToken = require('../middleware/verifyToken');
+const verifyRole = require('../middleware/verifyRole');
+const carePlanController = require('../controllers/carePlanController');
+
+/**
+ * @swagger
+ * tags:
+ *   - name: CarePlans
+ *     description: >
+ *       Care plan management. Design decisions: a patient may keep multiple historical care plans,
+ *       but only one plan may have `status=active` at a time; `caretaker` is required; `nurse` is optional;
+ *       `status` is explicit so the frontend can distinguish the active plan from inactive history.
+ *
+ * components:
+ *   schemas:
+ *     CarePlan:
+ *       type: object
+ *       required: [_id, title, patient, caretaker, status, tasks, created_at, updated_at]
+ *       properties:
+ *         _id: { type: string }
+ *         title: { type: string }
+ *         description: { type: string }
+ *         patient:
+ *           oneOf:
+ *             - type: string
+ *             - type: object
+ *         caretaker:
+ *           oneOf:
+ *             - type: string
+ *             - type: object
+ *         nurse:
+ *           nullable: true
+ *           oneOf:
+ *             - type: string
+ *             - type: object
+ *         status:
+ *           type: string
+ *           enum: [active, inactive]
+ *           description: Only one active care plan may exist per patient.
+ *         tasks:
+ *           type: array
+ *           items:
+ *             oneOf:
+ *               - type: string
+ *               - type: object
+ *         created_at: { type: string, format: date-time }
+ *         updated_at: { type: string, format: date-time }
+ *     CarePlanInput:
+ *       type: object
+ *       required: [title, patientId, caretakerId]
+ *       properties:
+ *         title: { type: string }
+ *         description: { type: string }
+ *         patientId:
+ *           type: string
+ *           description: Patient that owns the care plan.
+ *         caretakerId:
+ *           type: string
+ *           description: Required caretaker user ID.
+ *         nurseId:
+ *           type: string
+ *           nullable: true
+ *           description: Optional nurse user ID. Patients may have a care plan before a nurse is assigned.
+ *         tasks:
+ *           type: array
+ *           items: { type: string }
+ *           description: Optional task IDs. Every task must exist and belong to the same patient.
+ *     CarePlanUpdateInput:
+ *       type: object
+ *       properties:
+ *         title: { type: string }
+ *         description: { type: string }
+ *         caretakerId: { type: string }
+ *         nurseId:
+ *           type: string
+ *           nullable: true
+ *           description: Use null to remove the nurse assignment.
+ *         tasks:
+ *           type: array
+ *           items: { type: string }
+ *         status:
+ *           type: string
+ *           enum: [active, inactive]
+ *     CarePlanMutationResponse:
+ *       type: object
+ *       required: [message, carePlan]
+ *       properties:
+ *         message: { type: string }
+ *         carePlan: { $ref: '#/components/schemas/CarePlan' }
+ *     CarePlanListResponse:
+ *       type: object
+ *       required: [items, pagination]
+ *       properties:
+ *         items:
+ *           type: array
+ *           items: { $ref: '#/components/schemas/CarePlan' }
+ *         pagination:
+ *           type: object
+ *           required: [total, page, pages, limit]
+ *           properties:
+ *             total: { type: integer }
+ *             page: { type: integer }
+ *             pages: { type: integer }
+ *             limit: { type: integer }
+ *     CarePlanDetailResponse:
+ *       type: object
+ *       required: [carePlan]
+ *       properties:
+ *         carePlan: { $ref: '#/components/schemas/CarePlan' }
+ *     MessageResponse:
+ *       type: object
+ *       required: [message]
+ *       properties:
+ *         message: { type: string }
+ *     ErrorResponse:
+ *       type: object
+ *       required: [message]
+ *       properties:
+ *         message: { type: string }
+ *         details: { type: string }
+ *         carePlanId: { type: string }
+ */
+
+/**
+ * @swagger
+ * /api/v1/care-plans:
+ *   post:
+ *     tags: [CarePlans]
+ *     summary: Create a care plan
+ *     description: >
+ *       Creates a new active care plan. Only admins may create plans. If the patient already has an active plan,
+ *       the API returns 409 instead of silently replacing it.
+ *     security: [{ bearerAuth: [] }]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema: { $ref: '#/components/schemas/CarePlanInput' }
+ *     responses:
+ *       201:
+ *         description: Care plan created
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/CarePlanMutationResponse' }
+ *       400:
+ *         description: Missing fields, invalid IDs, role mismatch, or tasks from another patient
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       401:
+ *         description: Missing or invalid authentication token
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       403:
+ *         description: Authenticated user is not an admin
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       404:
+ *         description: Patient not found
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       409:
+ *         description: Patient already has an active care plan
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       500:
+ *         description: Error creating care plan
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ */
+router.post('/', verifyToken, verifyRole(['admin']), carePlanController.createCarePlan);
+
+/**
+ * @swagger
+ * /api/v1/care-plans:
+ *   get:
+ *     tags: [CarePlans]
+ *     summary: List care plans
+ *     description: >
+ *       Returns active and inactive plans. Clinical users can read plans; use `status=active`
+ *       when the frontend only needs the current plan.
+ *     security: [{ bearerAuth: [] }]
+ *     parameters:
+ *       - in: query
+ *         name: patientId
+ *         schema: { type: string }
+ *       - in: query
+ *         name: status
+ *         schema: { type: string, enum: [active, inactive] }
+ *       - in: query
+ *         name: page
+ *         schema: { type: integer, minimum: 1, default: 1 }
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer, minimum: 1, maximum: 100, default: 20 }
+ *     responses:
+ *       200:
+ *         description: Paged care plan list
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/CarePlanListResponse' }
+ *       400:
+ *         description: Invalid filter values
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       401:
+ *         description: Missing or invalid authentication token
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       403:
+ *         description: Authenticated user lacks a clinical role
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       500:
+ *         description: Error fetching care plans
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ */
+router.get('/', verifyToken, verifyRole(['admin', 'caretaker', 'nurse', 'doctor']), carePlanController.getCarePlans);
+
+/**
+ * @swagger
+ * /api/v1/care-plans/{carePlanId}:
+ *   get:
+ *     tags: [CarePlans]
+ *     summary: Get one care plan
+ *     security: [{ bearerAuth: [] }]
+ *     parameters:
+ *       - in: path
+ *         name: carePlanId
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: Care plan details
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/CarePlanDetailResponse' }
+ *       400:
+ *         description: Invalid care plan ID
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       401:
+ *         description: Missing or invalid authentication token
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       403:
+ *         description: Authenticated user lacks a clinical role
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       404:
+ *         description: Care plan not found
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       500:
+ *         description: Error fetching care plan
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ */
+router.get('/:carePlanId', verifyToken, verifyRole(['admin', 'caretaker', 'nurse', 'doctor']), carePlanController.getCarePlanById);
+
+/**
+ * @swagger
+ * /api/v1/care-plans/{carePlanId}:
+ *   put:
+ *     tags: [CarePlans]
+ *     summary: Update a care plan
+ *     description: >
+ *       Admin-only mutation. Setting `status=inactive` archives the plan. Setting an inactive plan back to
+ *       `active` fails with 409 when another active plan already exists for that patient.
+ *     security: [{ bearerAuth: [] }]
+ *     parameters:
+ *       - in: path
+ *         name: carePlanId
+ *         required: true
+ *         schema: { type: string }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema: { $ref: '#/components/schemas/CarePlanUpdateInput' }
+ *     responses:
+ *       200:
+ *         description: Care plan updated
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/CarePlanMutationResponse' }
+ *       400:
+ *         description: Invalid IDs, role mismatch, invalid status, or tasks from another patient
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       401:
+ *         description: Missing or invalid authentication token
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       403:
+ *         description: Authenticated user is not an admin
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       404:
+ *         description: Care plan not found
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       409:
+ *         description: Another active care plan already exists for the patient
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       500:
+ *         description: Error updating care plan
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ */
+router.put('/:carePlanId', verifyToken, verifyRole(['admin']), carePlanController.updateCarePlan);
+
+/**
+ * @swagger
+ * /api/v1/care-plans/{carePlanId}:
+ *   delete:
+ *     tags: [CarePlans]
+ *     summary: Delete a care plan
+ *     description: Permanently deletes a care plan. Use `status=inactive` when historical retention is required.
+ *     security: [{ bearerAuth: [] }]
+ *     parameters:
+ *       - in: path
+ *         name: carePlanId
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: Care plan deleted
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/MessageResponse' }
+ *       400:
+ *         description: Invalid care plan ID
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       401:
+ *         description: Missing or invalid authentication token
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       403:
+ *         description: Authenticated user is not an admin
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       404:
+ *         description: Care plan not found
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ *       500:
+ *         description: Error deleting care plan
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
+ */
+router.delete('/:carePlanId', verifyToken, verifyRole(['admin']), carePlanController.deleteCarePlan);
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -175,6 +175,7 @@ const adminStaffRoutes = require('./routes/adminStaffRoutes');
 const orgRoutes = require('./routes/orgRoutes');
 const prescriptionRoutes = require('./routes/prescriptionRoutes');
 const resourceRoutes = require('./routes/resourceRoutes');
+const carePlanRoutes = require('./routes/carePlanRoutes');
 app.use('/api/v1/auth', userRoutes);
 app.use('/api/v1/caretaker', caretakerRoutes);
 app.use('/api/v1/nurse', nurseRoutes);
@@ -192,6 +193,7 @@ app.use('/api/v1/admin', adminStaffRoutes);
 app.use('/api/v1/admin', adminPatientRoutes);
 app.use('/api/v1/orgs', orgRoutes);
 app.use('/api/v1/resources', resourceRoutes);
+app.use('/api/v1/care-plans', carePlanRoutes);
 
 app.use(
   '/swaggerDocs',


### PR DESCRIPTION
## Summary
- add CarePlan CRUD endpoints and mount `/api/v1/care-plans`
- normalize CarePlan user references to `User`
- document API design decisions in Swagger and return the active care plan from patient overview endpoints

## Design decisions
- one active care plan per patient; inactive historical plans are allowed
- caretaker is required
- nurse is optional
- explicit `status` field distinguishes active vs inactive plans

## Verification
- `node --check src/controllers/carePlanController.js`
- `node --check src/routes/carePlanRoutes.js`
- `node --check src/models/CarePlan.js`
- `node --check src/server.js`
- `git diff --check`
- full test run could not be completed locally because dependency installation fails on `pg-connection-string-2.13.0.tgz` returning npm 404