### PR TITLE
Replace description field with structured care plan fields

### DIFF
--- a/src/models/CarePlan.js
+++ b/src/models/CarePlan.js
@@ -2,13 +2,27 @@ const mongoose = require('mongoose');
 
 const CarePlanSchema = new mongoose.Schema({
   title: { type: String, required: true, trim: true },
-  description: { type: String, default: '', trim: true },
   tasks: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Task' }],
   patient: { type: mongoose.Schema.Types.ObjectId, ref: 'Patient', required: true },
   author: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   caretaker: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   nurse: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
   status: { type: String, enum: ['active', 'inactive'], default: 'active' },
+
+  // --- Replacing "description" with structured fields ---
+  approved_by: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+  approved_at: { type: Date, default: null },
+
+  effective_from: { type: Date, required: true, default: Date.now },
+  effective_to: { type: Date, default: null },
+  next_review_date: { type: Date, default: null },
+  last_reviewed_date: { type: Date, default: null },
+
+  dietary_requirements: { type: String, default: '', trim: true },
+
+  client_consent_flag: { type: Boolean, default: false },
+  consent_date: { type: Date, default: null },
+
   created_at: { type: Date, default: Date.now },
   updated_at: { type: Date, default: Date.now }
 });
@@ -31,6 +45,7 @@ CarePlanSchema.index({ patient: 1, created_at: -1 });
 CarePlanSchema.index({ caretaker: 1, status: 1 });
 CarePlanSchema.index({ nurse: 1, status: 1 });
 CarePlanSchema.index({ author: 1, created_at: -1 });
+CarePlanSchema.index({ next_review_date: 1, status: 1 });
 
 const CarePlan = mongoose.model('CarePlan', CarePlanSchema);
 


### PR DESCRIPTION
## Description

Replaced the `description` field on the `careplans` collection with a structured set of fields, per the task to design better fields for what a care plan actually contains.

Added:
- `approved_by`, `approved_at` — sign-off, separate from `author` (who wrote it)
- `effective_from`, `effective_to` — when the plan comes into/out of effect
- `next_review_date`, `last_reviewed_date` — review cycle tracking
- `dietary_requirements` — nutrition/meal info
- `client_consent_flag`, `consent_date` — consent tracking
- New index on `next_review_date` + `status` for review-due queries

`status` enum, existing indexes, and pre-save hooks were left unchanged — out of scope for this task.

### Todos

- [x] Tested and working locally
- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] Code changes documented
- [ ] Requested review from >= 1 devs on the team

### How to test

Run `docker-compose up --build` and confirm the app starts with no schema errors. Optionally, create a care plan via Postman and confirm the new fields save correctly.

### Known Issues

None currently.