### PR TITLE
Add patient indicators and update care plan API

### DIFF
--- a/src/controllers/carePlanController.js
+++ b/src/controllers/carePlanController.js
@@ -21,7 +21,8 @@ const POPULATE_OPTIONS = [
   { path: 'patient', select: 'fullname gender dateOfBirth caretaker assignedNurses' },
   { path: 'author', select: 'fullname email' },
   { path: 'caretaker', select: 'fullname email' },
-  { path: 'nurse', select: 'fullname email' }
+  { path: 'nurse', select: 'fullname email' },
+  { path: 'approved_by', select: 'fullname email' }
 ];
 
 function isValidObjectId(value) {
@@ -120,20 +121,21 @@ async function validateTasksForPatient(taskIds = [], patientId) {
   return { ok: true, tasks };
 }
 
+// caretaker and nurse are both optional: a care plan can be created
+// or updated without either assigned yet.
 async function validateCareTeam({ patient, caretakerId, nurseId }) {
   const nextCaretakerId = caretakerId || patient.caretaker;
 
-  if (!nextCaretakerId) {
-    return { ok: false, status: 400, message: 'caretakerId is required when the patient has no caretaker' };
-  }
+  let caretaker = null;
+  if (nextCaretakerId) {
+    if (!isValidObjectId(nextCaretakerId)) {
+      return { ok: false, status: 400, message: 'caretakerId must be a valid ID' };
+    }
 
-  if (!isValidObjectId(nextCaretakerId)) {
-    return { ok: false, status: 400, message: 'caretakerId must be a valid ID' };
-  }
-
-  const caretaker = await ensureUserWithRole(nextCaretakerId, 'caretaker');
-  if (!caretaker) {
-    return { ok: false, status: 400, message: 'caretakerId must reference a caretaker user' };
+    caretaker = await ensureUserWithRole(nextCaretakerId, 'caretaker');
+    if (!caretaker) {
+      return { ok: false, status: 400, message: 'caretakerId must reference a caretaker user' };
+    }
   }
 
   let nurse = null;
@@ -150,7 +152,7 @@ async function validateCareTeam({ patient, caretakerId, nurseId }) {
 
   return {
     ok: true,
-    caretakerId: caretaker._id,
+    caretakerId: caretaker ? caretaker._id : null,
     nurseId: nurse ? nurse._id : nurseId === null ? null : undefined
   };
 }
@@ -172,11 +174,93 @@ async function ensureNoOtherActivePlan(patientId, carePlanId = null) {
   };
 }
 
+/**
+ * Validates and normalizes the newer care plan fields (sign-off, effective
+ * dates, review cycle, dietary requirements, consent) from a request body.
+ * Accepts camelCase keys (matching the rest of this API's request format)
+ * and maps them to the schema's snake_case field names.
+ * Only keys that are actually present in the body are included in the
+ * returned updates object, so partial updates don't clobber existing values.
+ */
+async function validateCarePlanDetails(body = {}) {
+  const updates = {};
+
+  if (body.approvedBy !== undefined) {
+    if (body.approvedBy !== null && !isValidObjectId(body.approvedBy)) {
+      return { ok: false, status: 400, message: 'approvedBy must be a valid ID or null' };
+    }
+    if (body.approvedBy) {
+      const approver = await User.findById(body.approvedBy).select('_id').lean();
+      if (!approver) {
+        return { ok: false, status: 400, message: 'approvedBy must reference an existing user' };
+      }
+    }
+    updates.approved_by = body.approvedBy || null;
+  }
+
+  if (body.approvedAt !== undefined) {
+    if (body.approvedAt !== null && isNaN(Date.parse(body.approvedAt))) {
+      return { ok: false, status: 400, message: 'approvedAt must be a valid date or null' };
+    }
+    updates.approved_at = body.approvedAt ? new Date(body.approvedAt) : null;
+  }
+
+  if (body.effectiveFrom !== undefined) {
+    if (isNaN(Date.parse(body.effectiveFrom))) {
+      return { ok: false, status: 400, message: 'effectiveFrom must be a valid date' };
+    }
+    updates.effective_from = new Date(body.effectiveFrom);
+  }
+
+  if (body.effectiveTo !== undefined) {
+    if (body.effectiveTo !== null && isNaN(Date.parse(body.effectiveTo))) {
+      return { ok: false, status: 400, message: 'effectiveTo must be a valid date or null' };
+    }
+    updates.effective_to = body.effectiveTo ? new Date(body.effectiveTo) : null;
+  }
+
+  if (body.nextReviewDate !== undefined) {
+    if (body.nextReviewDate !== null && isNaN(Date.parse(body.nextReviewDate))) {
+      return { ok: false, status: 400, message: 'nextReviewDate must be a valid date or null' };
+    }
+    updates.next_review_date = body.nextReviewDate ? new Date(body.nextReviewDate) : null;
+  }
+
+  if (body.lastReviewedDate !== undefined) {
+    if (body.lastReviewedDate !== null && isNaN(Date.parse(body.lastReviewedDate))) {
+      return { ok: false, status: 400, message: 'lastReviewedDate must be a valid date or null' };
+    }
+    updates.last_reviewed_date = body.lastReviewedDate ? new Date(body.lastReviewedDate) : null;
+  }
+
+  if (body.dietaryRequirements !== undefined) {
+    if (typeof body.dietaryRequirements !== 'string') {
+      return { ok: false, status: 400, message: 'dietaryRequirements must be a string' };
+    }
+    updates.dietary_requirements = body.dietaryRequirements.trim();
+  }
+
+  if (body.clientConsentFlag !== undefined) {
+    if (typeof body.clientConsentFlag !== 'boolean') {
+      return { ok: false, status: 400, message: 'clientConsentFlag must be a boolean' };
+    }
+    updates.client_consent_flag = body.clientConsentFlag;
+  }
+
+  if (body.consentDate !== undefined) {
+    if (body.consentDate !== null && isNaN(Date.parse(body.consentDate))) {
+      return { ok: false, status: 400, message: 'consentDate must be a valid date or null' };
+    }
+    updates.consent_date = body.consentDate ? new Date(body.consentDate) : null;
+  }
+
+  return { ok: true, updates };
+}
+
 exports.createCarePlan = async (req, res) => {
   try {
     const {
       title,
-      description = '',
       patientId,
       caretakerId,
       nurseId = null,
@@ -201,6 +285,9 @@ exports.createCarePlan = async (req, res) => {
     const taskAccess = await validateTasksForPatient(tasks, patientId);
     if (!taskAccess.ok) return res.status(taskAccess.status).json({ message: taskAccess.message });
 
+    const detailsAccess = await validateCarePlanDetails(req.body);
+    if (!detailsAccess.ok) return res.status(detailsAccess.status).json({ message: detailsAccess.message });
+
     if (status === 'active') {
       const activePlan = await ensureNoOtherActivePlan(patientId);
       if (!activePlan.ok) {
@@ -213,13 +300,13 @@ exports.createCarePlan = async (req, res) => {
 
     const carePlan = await CarePlan.create({
       title,
-      description,
       patient: patientId,
       author: req.user._id,
       caretaker: careTeam.caretakerId,
       nurse: careTeam.nurseId ?? null,
       tasks,
-      status
+      status,
+      ...detailsAccess.updates
     });
 
     notify(notifyRules.carePlanCreated({
@@ -328,7 +415,6 @@ exports.updateCarePlan = async (req, res) => {
     const { carePlanId } = req.params;
     const {
       title,
-      description,
       patientId,
       patient,
       caretakerId,
@@ -362,9 +448,11 @@ exports.updateCarePlan = async (req, res) => {
     const taskAccess = await validateTasksForPatient(nextTasks || [], nextPatientId);
     if (!taskAccess.ok) return res.status(taskAccess.status).json({ message: taskAccess.message });
 
-    const updates = {};
+    const detailsAccess = await validateCarePlanDetails(req.body);
+    if (!detailsAccess.ok) return res.status(detailsAccess.status).json({ message: detailsAccess.message });
+
+    const updates = { ...detailsAccess.updates };
     if (title !== undefined) updates.title = title;
-    if (description !== undefined) updates.description = description;
     if (patientId || patient) updates.patient = nextPatientId;
     if (tasks !== undefined) updates.tasks = tasks;
 

--- a/src/controllers/indicatorController.js
+++ b/src/controllers/indicatorController.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const Indicator = require('../models/Indicator');
+const Patient = require('../models/Patient');
+
+/* --------------------------- Helper Functions --------------------------- */
+
+const sendControllerError = (res, err, fallbackMessage) => {
+  if (err?.status) {
+    return res.status(err.status).json({ message: err.message });
+  }
+  return res.status(500).json({ message: fallbackMessage, details: err.message });
+};
+
+/* ---------------------------------------------------------------------- */
+
+exports.createIndicator = async (req, res) => {
+  try {
+    const { patient, careplan, indicator_type, severity, notes } = req.body || {};
+
+    if (!patient || !indicator_type) {
+      return res.status(400).json({ message: 'patient and indicator_type are required' });
+    }
+
+    const patientDoc = await Patient.findById(patient);
+    if (!patientDoc) return res.status(404).json({ message: 'Patient not found' });
+
+    const indicator = await Indicator.create({
+      patient,
+      careplan: careplan || null,
+      indicator_type,
+      severity,
+      notes,
+      recorded_by: req.user._id
+    });
+
+    return res.status(201).json({ message: 'Indicator recorded', indicator });
+  } catch (err) {
+    return sendControllerError(res, err, 'Error creating indicator');
+  }
+};
+
+/* ---------------------------------------------------------------------- */
+
+exports.listIndicators = async (req, res) => {
+  try {
+    const { status, page = 1, limit = 10 } = req.query;
+    const filter = status ? { status } : {};
+
+    const p = Math.max(1, parseInt(page, 10));
+    const l = Math.min(100, Math.max(1, parseInt(limit, 10)));
+
+    const [indicators, total] = await Promise.all([
+      Indicator.find(filter)
+        .populate('patient', 'fullname')
+        .populate('recorded_by', 'fullname email')
+        .populate('actions.performed_by', 'fullname email')
+        .sort({ created_at: -1 })
+        .skip((p - 1) * l)
+        .limit(l)
+        .lean(),
+      Indicator.countDocuments(filter)
+    ]);
+
+    return res.status(200).json({
+      indicators,
+      pagination: { total, page: p, pages: Math.ceil(total / l), limit: l }
+    });
+  } catch (err) {
+    return sendControllerError(res, err, 'Error listing indicators');
+  }
+};
+
+/* ---------------------------------------------------------------------- */
+
+exports.listByPatient = async (req, res) => {
+  try {
+    const { patientId } = req.params;
+
+    const indicators = await Indicator.find({ patient: patientId })
+      .populate('recorded_by', 'fullname email')
+      .populate('actions.performed_by', 'fullname email')
+      .sort({ created_at: -1 });
+
+    return res.status(200).json({ indicators });
+  } catch (err) {
+    return sendControllerError(res, err, 'Error fetching indicators for patient');
+  }
+};
+
+/* ---------------------------------------------------------------------- */
+
+exports.getIndicator = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    const indicator = await Indicator.findById(id)
+      .populate('patient', 'fullname')
+      .populate('recorded_by', 'fullname email')
+      .populate('actions.performed_by', 'fullname email');
+
+    if (!indicator) return res.status(404).json({ message: 'Indicator not found' });
+
+    return res.status(200).json({ indicator });
+  } catch (err) {
+    return sendControllerError(res, err, 'Error fetching indicator');
+  }
+};
+
+/* ---------------------------------------------------------------------- */
+
+exports.updateIndicator = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { severity, status, notes } = req.body || {};
+
+    const updates = {};
+    if (severity) updates.severity = severity;
+    if (status) updates.status = status;
+    if (notes !== undefined) updates.notes = notes;
+
+    if (!Object.keys(updates).length) {
+      return res.status(400).json({ message: 'No valid fields to update' });
+    }
+
+    const indicator = await Indicator.findByIdAndUpdate(id, { $set: updates }, { new: true });
+    if (!indicator) return res.status(404).json({ message: 'Indicator not found' });
+
+    return res.status(200).json({ message: 'Indicator updated', indicator });
+  } catch (err) {
+    return sendControllerError(res, err, 'Error updating indicator');
+  }
+};
+
+/* ---------------------------------------------------------------------- */
+
+exports.addAction = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { action_type, description, outcome_notes } = req.body || {};
+
+    if (!action_type) {
+      return res.status(400).json({ message: 'action_type is required' });
+    }
+
+    const indicator = await Indicator.findById(id);
+    if (!indicator) return res.status(404).json({ message: 'Indicator not found' });
+
+    indicator.actions.push({
+      action_type,
+      description,
+      outcome_notes,
+      performed_by: req.user._id
+    });
+
+    await indicator.save();
+
+    return res.status(201).json({ message: 'Action recorded', indicator });
+  } catch (err) {
+    return sendControllerError(res, err, 'Error adding action');
+  }
+};
+
+/* ---------------------------------------------------------------------- */
+
+exports.deleteIndicator = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    const indicator = await Indicator.findByIdAndDelete(id);
+    if (!indicator) return res.status(404).json({ message: 'Indicator not found' });
+
+    return res.status(200).json({ message: 'Indicator deleted' });
+  } catch (err) {
+    return sendControllerError(res, err, 'Error deleting indicator');
+  }
+};

--- a/src/models/CarePlan.js
+++ b/src/models/CarePlan.js
@@ -2,13 +2,26 @@ const mongoose = require('mongoose');
 
 const CarePlanSchema = new mongoose.Schema({
   title: { type: String, required: true, trim: true },
-  description: { type: String, default: '', trim: true },
   tasks: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Task' }],
   patient: { type: mongoose.Schema.Types.ObjectId, ref: 'Patient', required: true },
   author: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
-  caretaker: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  caretaker: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
   nurse: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
   status: { type: String, enum: ['active', 'inactive'], default: 'active' },
+
+  approved_by: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+  approved_at: { type: Date, default: null },
+
+  effective_from: { type: Date, required: true, default: Date.now },
+  effective_to: { type: Date, default: null },
+  next_review_date: { type: Date, default: null },
+  last_reviewed_date: { type: Date, default: null },
+
+  dietary_requirements: { type: String, default: '', trim: true },
+
+  client_consent_flag: { type: Boolean, default: false },
+  consent_date: { type: Date, default: null },
+
   created_at: { type: Date, default: Date.now },
   updated_at: { type: Date, default: Date.now }
 });
@@ -31,6 +44,7 @@ CarePlanSchema.index({ patient: 1, created_at: -1 });
 CarePlanSchema.index({ caretaker: 1, status: 1 });
 CarePlanSchema.index({ nurse: 1, status: 1 });
 CarePlanSchema.index({ author: 1, created_at: -1 });
+CarePlanSchema.index({ next_review_date: 1, status: 1 });
 
 const CarePlan = mongoose.model('CarePlan', CarePlanSchema);
 

--- a/src/models/Indicator.js
+++ b/src/models/Indicator.js
@@ -1,0 +1,52 @@
+const mongoose = require('mongoose');
+
+// Nested sub-document: a single staff response to an indicator.
+// Embedded (not a separate collection) because actions are always
+// read/written together with their parent indicator.
+const ActionSchema = new mongoose.Schema(
+  {
+    action_type: { type: String, required: true, trim: true }, // e.g. "monitored", "notified_doctor", "medication_adjusted"
+    description: { type: String, default: '', trim: true },
+    performed_by: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    performed_at: { type: Date, default: Date.now },
+    outcome_notes: { type: String, default: '', trim: true }
+  },
+  { _id: true }
+);
+
+const IndicatorSchema = new mongoose.Schema({
+  patient: { type: mongoose.Schema.Types.ObjectId, ref: 'Patient', required: true },
+  careplan: { type: mongoose.Schema.Types.ObjectId, ref: 'CarePlan', default: null }, // optional link
+
+  indicator_type: { type: String, required: true, trim: true }, // e.g. "fatigue", "pain", "confusion"
+  severity: { type: String, enum: ['low', 'moderate', 'high'], default: 'low' },
+  notes: { type: String, default: '', trim: true },
+
+  recorded_by: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  recorded_at: { type: Date, default: Date.now },
+
+  status: { type: String, enum: ['open', 'resolved'], default: 'open' },
+
+  actions: [ActionSchema],
+
+  created_at: { type: Date, default: Date.now },
+  updated_at: { type: Date, default: Date.now }
+});
+
+IndicatorSchema.pre('save', function (next) {
+  this.updated_at = Date.now();
+  next();
+});
+
+IndicatorSchema.pre('findOneAndUpdate', function (next) {
+  this.set({ updated_at: Date.now() });
+  next();
+});
+
+IndicatorSchema.index({ patient: 1, status: 1 });
+IndicatorSchema.index({ careplan: 1, status: 1 });
+IndicatorSchema.index({ recorded_by: 1, created_at: -1 });
+
+const Indicator = mongoose.model('Indicator', IndicatorSchema);
+
+module.exports = Indicator;

--- a/src/routes/carePlanRoutes.js
+++ b/src/routes/carePlanRoutes.js
@@ -19,10 +19,9 @@ router.use(verifyToken, verifyRole(['admin', 'caretaker', 'nurse', 'doctor']));
  *       properties:
  *         _id: { type: string }
  *         title: { type: string }
- *         description: { type: string }
  *         patient: { type: string }
  *         author: { type: string }
- *         caretaker: { type: string }
+ *         caretaker: { type: string, nullable: true }
  *         nurse: { type: string, nullable: true }
  *         status:
  *           type: string
@@ -30,6 +29,15 @@ router.use(verifyToken, verifyRole(['admin', 'caretaker', 'nurse', 'doctor']));
  *         tasks:
  *           type: array
  *           items: { type: string }
+ *         approved_by: { type: string, nullable: true }
+ *         approved_at: { type: string, format: date-time, nullable: true }
+ *         effective_from: { type: string, format: date-time }
+ *         effective_to: { type: string, format: date-time, nullable: true }
+ *         next_review_date: { type: string, format: date-time, nullable: true }
+ *         last_reviewed_date: { type: string, format: date-time, nullable: true }
+ *         dietary_requirements: { type: string }
+ *         client_consent_flag: { type: boolean }
+ *         consent_date: { type: string, format: date-time, nullable: true }
  *         created_at: { type: string, format: date-time }
  *         updated_at: { type: string, format: date-time }
  */
@@ -51,7 +59,6 @@ router.use(verifyToken, verifyRole(['admin', 'caretaker', 'nurse', 'doctor']));
  *             required: [title, patientId]
  *             properties:
  *               title: { type: string }
- *               description: { type: string }
  *               patientId: { type: string }
  *               caretakerId:
  *                 type: string
@@ -63,6 +70,23 @@ router.use(verifyToken, verifyRole(['admin', 'caretaker', 'nurse', 'doctor']));
  *               tasks:
  *                 type: array
  *                 items: { type: string }
+ *               approvedBy:
+ *                 type: string
+ *                 nullable: true
+ *                 description: User ID of the staff member who signed off on the plan.
+ *               approvedAt: { type: string, format: date-time, nullable: true }
+ *               effectiveFrom:
+ *                 type: string
+ *                 format: date-time
+ *                 description: When the plan comes into effect. Defaults to now if omitted.
+ *               effectiveTo: { type: string, format: date-time, nullable: true }
+ *               nextReviewDate: { type: string, format: date-time, nullable: true }
+ *               lastReviewedDate: { type: string, format: date-time, nullable: true }
+ *               dietaryRequirements:
+ *                 type: string
+ *                 description: Allergies, texture-modified diet, or other dietary notes.
+ *               clientConsentFlag: { type: boolean }
+ *               consentDate: { type: string, format: date-time, nullable: true }
  *     responses:
  *       201:
  *         description: Care plan created
@@ -154,6 +178,33 @@ router.get('/:carePlanId', carePlanController.getCarePlanById);
  *         name: carePlanId
  *         required: true
  *         schema: { type: string }
+ *     requestBody:
+ *       required: false
+ *       description: All fields optional. Only fields included in the body are updated.
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               title: { type: string }
+ *               patientId: { type: string }
+ *               caretakerId: { type: string, nullable: true }
+ *               nurseId: { type: string, nullable: true }
+ *               status:
+ *                 type: string
+ *                 enum: [active, inactive]
+ *               tasks:
+ *                 type: array
+ *                 items: { type: string }
+ *               approvedBy: { type: string, nullable: true }
+ *               approvedAt: { type: string, format: date-time, nullable: true }
+ *               effectiveFrom: { type: string, format: date-time }
+ *               effectiveTo: { type: string, format: date-time, nullable: true }
+ *               nextReviewDate: { type: string, format: date-time, nullable: true }
+ *               lastReviewedDate: { type: string, format: date-time, nullable: true }
+ *               dietaryRequirements: { type: string }
+ *               clientConsentFlag: { type: boolean }
+ *               consentDate: { type: string, format: date-time, nullable: true }
  *     responses:
  *       200:
  *         description: Care plan updated

--- a/src/routes/indicatorRoutes.js
+++ b/src/routes/indicatorRoutes.js
@@ -1,0 +1,137 @@
+const express = require('express');
+const router = express.Router();
+
+const verifyToken = require('../middleware/verifyToken');
+const verifyRole = require('../middleware/verifyRole');
+
+const indicatorController = require('../controllers/indicatorController');
+
+// allow only logged-in medical staff (nurse, caretaker, doctor) on these routes
+router.use(verifyToken, verifyRole(['nurse', 'caretaker', 'doctor']));
+
+/**
+ * @openapi
+ * /api/v1/indicators:
+ *   post:
+ *     tags:
+ *       - Indicators
+ *     summary: Record a new patient indicator
+ *     description: >
+ *       Records an observed indicator for a patient (e.g. fatigue, pain, confusion),
+ *       optionally linked to an active care plan.
+ *       **Roles:** nurse, caretaker, doctor.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       201:
+ *         description: Indicator recorded successfully
+ *       400:
+ *         description: Validation error
+ *       404:
+ *         description: Patient not found
+ */
+router.post('/', indicatorController.createIndicator);
+
+/**
+ * @openapi
+ * /api/v1/indicators:
+ *   get:
+ *     tags:
+ *       - Indicators
+ *     summary: List all indicators (paginated, optional status filter)
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Paginated list of indicators
+ */
+router.get('/', indicatorController.listIndicators);
+
+/**
+ * @openapi
+ * /api/v1/indicators/patient/{patientId}:
+ *   get:
+ *     tags:
+ *       - Indicators
+ *     summary: Get all indicators for a specific patient
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of indicators for the patient
+ */
+router.get('/patient/:patientId', indicatorController.listByPatient);
+
+/**
+ * @openapi
+ * /api/v1/indicators/{id}:
+ *   get:
+ *     tags:
+ *       - Indicators
+ *     summary: Get one indicator by ID
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Indicator details
+ *       404:
+ *         description: Indicator not found
+ */
+router.get('/:id', indicatorController.getIndicator);
+
+/**
+ * @openapi
+ * /api/v1/indicators/{id}:
+ *   put:
+ *     tags:
+ *       - Indicators
+ *     summary: Update an indicator (severity, status, notes)
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Indicator updated
+ *       404:
+ *         description: Indicator not found
+ */
+router.put('/:id', indicatorController.updateIndicator);
+
+/**
+ * @openapi
+ * /api/v1/indicators/{id}/actions:
+ *   post:
+ *     tags:
+ *       - Indicators
+ *     summary: Add a staff action in response to an indicator
+ *     description: >
+ *       Appends a new action to the indicator's action history, recording what
+ *       the medical staff member did in response and who performed it.
+ *       **Roles:** nurse, caretaker, doctor.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       201:
+ *         description: Action recorded
+ *       404:
+ *         description: Indicator not found
+ */
+router.post('/:id/actions', indicatorController.addAction);
+
+/**
+ * @openapi
+ * /api/v1/indicators/{id}:
+ *   delete:
+ *     tags:
+ *       - Indicators
+ *     summary: Delete an indicator
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Indicator deleted
+ *       404:
+ *         description: Indicator not found
+ */
+router.delete('/:id', indicatorController.deleteIndicator);
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -191,6 +191,7 @@ const taskRoutes = require('./routes/taskRoutes');
 const carePlanRoutes = require('./routes/carePlanRoutes');
 const resourceRoutes = require('./routes/resourceRoutes');
 const testRoutes = require('./routes/testRoutes');
+const indicatorRoutes = require('./routes/indicatorRoutes');
 
 app.use('/api/v1/auth', userRoutes);
 app.use('/api/v1/caretaker', caretakerRoutes);
@@ -212,6 +213,7 @@ app.use('/api/v1/tasks', taskRoutes);
 app.use('/api/v1/care-plans', carePlanRoutes);
 app.use('/api/v1/resources', resourceRoutes);
 app.use('/api/v1/test', testRoutes);
+app.use('/api/v1/indicators', indicatorRoutes);
 
 app.use(
   '/swaggerDocs',


### PR DESCRIPTION
## Description

Adds a new patient indicators feature and updates the care plan API, per task assignment.

**New: Patient Indicators**
- New `Indicator` model with nested staff `actions` array (indicator + response history in one document)
- `patient` required, `careplan` optional, an indicator can be logged with or without an active care plan
- New standalone API at `/api/v1/indicators`, restricted to nurse/caretaker/doctor roles
- Endpoints: create, list all, list by patient, get one, update, delete, add action

**Care Plan updates**
- `caretaker` is now optional (previously required).
- `validateCareTeam` updated so a care plan can be created/updated without a caretaker
- Added full API support (create + update) for the fields introduced in the previous PR: `approvedBy`, `approvedAt`, `effectiveFrom`, `effectiveTo`, `nextReviewDate`, `lastReviewedDate`, `dietaryRequirements`, `clientConsentFlag`, `consentDate`, these existed on the schema but weren't previously readable/writable through the API
- Removed remaining `description` references from the controller.

### Todos

- [x] Tested and working locally
- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] Code changes documented
- [ ] Requested review from >= 1 devs on the team

### How to test

Run `docker-compose up --build`, confirm "Server running on port 3000" and "MongoDB connected successfully" with no errors. Check `/swaggerDocs` for a new "Indicators" section. Optionally, POST a new indicator and PUT a care plan update including the new fields to confirm they save correctly.

### Known Issues

None currently.