### PR TITLE
Add Billing feature: schema, model, and CRUD API

### DIFF
--- a/src/controllers/billingController.js
+++ b/src/controllers/billingController.js
@@ -1,0 +1,97 @@
+const Billing = require('../models/billing');
+
+// CREATE
+exports.createBilling = async (req, res) => {
+  try {
+    const {
+      patientId,
+      service_rendered,
+      description,
+      payee_name,
+      payer_name,
+      workcover_membership_no,
+      workcover_reimbursement_rate,
+      amount_owed,
+      payment_status,
+      medicare_rebate
+    } = req.body;
+
+    const billing = new Billing({
+      patient: patientId,
+      service_rendered,
+      description,
+      payee_name,
+      payer_name,
+      workcover_membership_no,
+      workcover_reimbursement_rate,
+      amount_owed,
+      payment_status: payment_status || 'sent',
+      medicare_rebate
+    });
+
+    await billing.save();
+    res.status(201).json(billing);
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+};
+
+// READ - single record
+exports.getBillingById = async (req, res) => {
+  try {
+    const billing = await Billing.findById(req.params.id);
+    if (!billing) {
+      return res.status(404).json({ message: 'Billing record not found' });
+    }
+    res.status(200).json(billing);
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+};
+
+// READ - all records
+exports.getAllBillings = async (req, res) => {
+  try {
+    const billings = await Billing.find();
+    res.status(200).json(billings);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+// UPDATE
+exports.updateBilling = async (req, res) => {
+  try {
+    const updates = { ...req.body, updated_at: Date.now() };
+
+    // map the *Id-style fields onto their schema reference names, if present
+    if (req.body.patientId) updates.patient = req.body.patientId;
+    if (req.body.locationId) updates.location = req.body.locationId;
+    if (req.body.providerId) updates.provider = req.body.providerId;
+
+    const billing = await Billing.findByIdAndUpdate(req.params.id, updates, {
+      new: true,
+      runValidators: true
+    });
+
+    if (!billing) {
+      return res.status(404).json({ message: 'Billing record not found' });
+    }
+    res.status(200).json(billing);
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+};
+
+// DELETE
+exports.deleteBilling = async (req, res) => {
+  try {
+    const billing = await Billing.findByIdAndDelete(req.params.id);
+    if (!billing) {
+      return res.status(404).json({ message: 'Billing record not found' });
+    }
+    res.status(200).json({ message: 'Billing record deleted successfully' });
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+};

--- a/src/models/billing.js
+++ b/src/models/billing.js
@@ -1,0 +1,28 @@
+const mongoose = require("mongoose");
+
+const BillingSchema = new mongoose.Schema({
+  patient: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "Patient",
+    required: true,
+  },
+  service_rendered: { type: String, required: true },
+  description: { type: String },
+  payee_name: { type: String, required: true },
+  payer_name: { type: String, required: true },
+  workcover_membership_no: { type: String },
+  workcover_reimbursement_rate: { type: Number },
+  amount_owed: { type: Number, required: true },
+  payment_status: {
+    type: String,
+    enum: ["sent", "received", "paid", "rejected"],
+    required: true,
+  },
+  medicare_rebate: { type: Number },
+  created_at: { type: Date, default: Date.now },
+  updated_at: { type: Date, default: Date.now },
+});
+
+const Billing = mongoose.model("Billing", BillingSchema);
+
+module.exports = Billing;

--- a/src/models/billing.js
+++ b/src/models/billing.js
@@ -1,11 +1,7 @@
-const mongoose = require("mongoose");
+const mongoose = require('mongoose');
 
 const BillingSchema = new mongoose.Schema({
-  patient: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: "Patient",
-    required: true,
-  },
+  patient: { type: mongoose.Schema.Types.ObjectId, ref: 'Patient', required: true },
   service_rendered: { type: String, required: true },
   description: { type: String },
   payee_name: { type: String, required: true },
@@ -15,14 +11,42 @@ const BillingSchema = new mongoose.Schema({
   amount_owed: { type: Number, required: true },
   payment_status: {
     type: String,
-    enum: ["sent", "received", "paid", "rejected"],
-    required: true,
+    enum: ['sent', 'received', 'paid', 'rejected'],
+    required: true
   },
   medicare_rebate: { type: Number },
+
+  invoice_date: { type: Date },
+  invoice_no: { type: Number },
+  location: { type: mongoose.Schema.Types.ObjectId, ref: 'Location' },
+  provider: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  service_date: { type: Date },
+  bill_to: {
+    type: String,
+    enum: ['Patient', 'head of family', 'Medicare', 'DVA', 'health Insurance', 'other']
+  },
+  billing_schedule: {
+    type: String,
+    enum: ['Practice Fee', 'Concession fee', 'Rebate only', 'Work Cover', 'TAC']
+  },
+  medicare_item_no: { type: Number },
+  amount: { type: Number },
+  gst: { type: Number },
+  total: { type: Number },
+  visit_duration: { type: String },
+  notes_from_provider: { type: String },
+  notes: { type: String },
+  not_normal_aftercare: { type: Boolean },
+  restriction_codes: {
+    type: String,
+    enum: ['not related', 'not for comparison', 'separate site']
+  },
+  payment_pending: { type: Boolean },
+
   created_at: { type: Date, default: Date.now },
-  updated_at: { type: Date, default: Date.now },
+  updated_at: { type: Date, default: Date.now }
 });
 
-const Billing = mongoose.model("Billing", BillingSchema);
+const Billing = mongoose.model('Billing', BillingSchema);
 
 module.exports = Billing;

--- a/src/routes/billingRoutes.js
+++ b/src/routes/billingRoutes.js
@@ -1,0 +1,144 @@
+const express = require('express');
+const router = express.Router();
+const {
+  createBilling,
+  getBillingById,
+  getAllBillings,
+  updateBilling,
+  deleteBilling
+} = require('../controllers/billingController');
+
+/**
+ * @swagger
+ * /api/v1/billing:
+ *   post:
+ *     summary: Create a new billing record
+ *     tags: [Billing]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - patientId
+ *               - service_rendered
+ *               - payee_name
+ *               - payer_name
+ *               - amount_owed
+ *             properties:
+ *               patientId:
+ *                 type: string
+ *                 example: 64f1a2b3c4d5e6f7a8b9c0d1
+ *               service_rendered:
+ *                 type: string
+ *                 example: Physiotherapy session
+ *               payee_name:
+ *                 type: string
+ *                 example: Gopher Physiotherapy Clinic
+ *               payer_name:
+ *                 type: string
+ *                 example: Medicare
+ *               amount_owed:
+ *                 type: number
+ *                 example: 120.00
+ *               payment_status:
+ *                 type: string
+ *                 enum: [sent, received, paid, rejected]
+ *     responses:
+ *       201:
+ *         description: Billing record created successfully
+ *       400:
+ *         description: Invalid input / validation error
+ */
+router.post('/', createBilling);
+
+/**
+ * @swagger
+ * /api/v1/billing:
+ *   get:
+ *     summary: Get all billing records
+ *     tags: [Billing]
+ *     responses:
+ *       200:
+ *         description: List of billing records
+ *       500:
+ *         description: Server error
+ */
+router.get('/', getAllBillings);
+
+/**
+ * @swagger
+ * /api/v1/billing/{id}:
+ *   get:
+ *     summary: Get a single billing record by ID
+ *     tags: [Billing]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Billing record found
+ *       404:
+ *         description: Billing record not found
+ */
+router.get('/:id', getBillingById);
+
+/**
+ * @swagger
+ * /api/v1/billing/{id}:
+ *   put:
+ *     summary: Update a billing record by ID
+ *     tags: [Billing]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               payment_status:
+ *                 type: string
+ *                 enum: [sent, received, paid, rejected]
+ *               amount_owed:
+ *                 type: number
+ *     responses:
+ *       200:
+ *         description: Billing record updated successfully
+ *       404:
+ *         description: Billing record not found
+ *       400:
+ *         description: Invalid input / validation error
+ */
+router.put('/:id', updateBilling);
+
+/**
+ * @swagger
+ * /api/v1/billing/{id}:
+ *   delete:
+ *     summary: Delete a billing record by ID
+ *     tags: [Billing]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Billing record deleted successfully
+ *       404:
+ *         description: Billing record not found
+ */
+router.delete('/:id', deleteBilling);
+
+module.exports = router;


### PR DESCRIPTION
## What this adds
- Billing schema/model with all fields from the updated design (invoice details, location/provider references, WorkCover, Medicare, GST, restriction codes, etc.)
- Full CRUD API for Billing:
  - POST /api/v1/billing — create
  - GET /api/v1/billing — get all
  - GET /api/v1/billing/:id — get one
  - PUT /api/v1/billing/:id — update
  - DELETE /api/v1/billing/:id — delete
- Swagger documentation for all endpoints

## Testing
All endpoints tested locally via curl and Swagger UI — create, read (single + all), update, and delete all confirmed working against MongoDB.